### PR TITLE
In pcap.c pcap_setnonblock doesn't accept captured files anymore

### DIFF
--- a/dsc/trunk/collector/dsc/pcap.c
+++ b/dsc/trunk/collector/dsc/pcap.c
@@ -776,7 +776,7 @@ Pcap_init(const char *device, int promisc)
 	syslog(LOG_ERR, "pcap_open_*: %s", errbuf);
 	exit(1);
     }
-    if (pcap_setnonblock(i->pcap, 1, errbuf) < 0) {
+    if (!pcap_file(i->pcap) && pcap_setnonblock(i->pcap, 1, errbuf) < 0) {
 	syslog(LOG_ERR, "pcap_setnonblock(%s): %s", device, errbuf);
 	exit(1);
     }


### PR DESCRIPTION
In libpcap, savefile.c function sf_setnonblock(pcap_t *p, int nonblock, char *errbuf) was changed on 28th May, 2010 such that if provided device is a saved file, it returns -1 instead of 0. Details here: https://github.com/the-tcpdump-group/libpcap/commit/65f960da711ceb2de336c4c3b0ab23578820724d
Above mentioned problem causes DSC to abort when we use a pcap file as an interface in dsc configuration.   This patch suggests a simple fix.

My Environment: Linux 4.1.10-100.fc21.x86_64 (Fedoracore 21)