### PR TITLE
Give option for additional output JSON/Extended JSON

### DIFF
--- a/collector/dsc/Makefile.in
+++ b/collector/dsc/Makefile.in
@@ -33,6 +33,7 @@ OBJS=\
 	client_ip_net_index.o \
 	server_ip_addr_index.o \
 	md_array_xml_printer.o \
+	md_array_json_printer.o \
 	ip_direction_index.o \
 	ip_proto_index.o \
 	ip_version_index.o \

--- a/collector/dsc/config_hooks.c
+++ b/collector/dsc/config_hooks.c
@@ -15,6 +15,8 @@ void Ncap_init(const char *device, int promisc);
 #endif
 void Pcap_init(const char *device, int promisc);
 uint64_t minfree_bytes = 0;
+char output_json = 0;
+char output_ext_json = 0;
 
 int
 open_interface(const char *interface)
@@ -116,4 +118,34 @@ set_minfree_bytes(const char *s)
     syslog(LOG_INFO, "minfree_bytes %s", s);
     minfree_bytes = strtoull(s, NULL, 10);
     return 1;
+}
+
+int check_unique_json_output(const char *output_format)
+{
+    if (output_json || output_ext_json) {
+        syslog(LOG_ERR, "add_output '%s' set but a json-like additional output already exists", output_format);
+        return 0;
+    }
+    return 1;
+}
+
+int
+set_additional_output(const char *output_format)
+{
+    syslog(LOG_INFO, "add_output %s", output_format);
+
+    if (0 == strcmp(output_format, "json")) {
+        if (!check_unique_json_output(output_format))
+            return 0;
+        output_json = 1;
+        return 1;
+    }
+    if (0 == strcmp(output_format, "ext_json")) {
+        if (!check_unique_json_output(output_format))
+            return 0;
+        output_ext_json = 1;
+        return 1;
+    }
+    syslog(LOG_ERR, "unknown add_output '%s'", output_format);
+    return 0;
 }

--- a/collector/dsc/dns_message.c
+++ b/collector/dsc/dns_message.c
@@ -18,7 +18,6 @@
 
 #include "xmalloc.h"
 #include "dns_message.h"
-#include "md_array.h"
 #include "null_index.h"
 #include "qtype_index.h"
 #include "qclass_index.h"
@@ -53,7 +52,6 @@
 
 #include "syslog_debug.h"
 
-extern md_array_printer xml_printer;
 extern int debug_flag;
 static md_array_list *Arrays = NULL;
 static filter_list *DNSFilters = NULL;
@@ -348,11 +346,12 @@ dns_message_add_array(const char *name, const char *fn, const char *fi,
 }
 
 void
-dns_message_report(FILE * fp)
+dns_message_report(FILE *fp, md_array_printer *printer)
 {
     md_array_list *a;
-    for (a = Arrays; a; a = a->next)
-	md_array_print(a->theArray, &xml_printer, fp);
+    for (a = Arrays; a; a = a->next) {
+        md_array_print(a->theArray, printer, fp);
+    }
 }
 
 void

--- a/collector/dsc/dns_message.h
+++ b/collector/dsc/dns_message.h
@@ -7,6 +7,7 @@
 
 #include "inX_addr.h"
 #include "dataset_opt.h"
+#include "md_array.h"
 
 #define MAX_QNAME_SZ 512
 
@@ -49,11 +50,10 @@ struct _dns_message
     /* ... */
 };
 
-void dns_message_report(FILE *);
-int dns_message_add_array(const char *, const char *, const char *, const char *, const char *, const char *,
-    dataset_opt);
-const char *dns_message_QnameToNld(const char *, int);
-const char *dns_message_tld(dns_message * m);
+void dns_message_report(FILE *, md_array_printer *);
+int dns_message_add_array(const char *, const char *,const char *,const char *,const char *,const char *, dataset_opt);
+const char * dns_message_QnameToNld(const char *, int);
+const char * dns_message_tld(dns_message * m);
 void dns_message_init(void);
 void dns_message_clear_arrays(void);
 void dns_message_handle(dns_message *);

--- a/collector/dsc/dsc.conf.sample
+++ b/collector/dsc/dsc.conf.sample
@@ -22,6 +22,16 @@ run_dir "/usr/local/dsc/run/NODENAME";
 #
 minfree_bytes 5000000;
 
+
+# add_output
+#       Set an additional output format. Files with this format 
+#       will be generated along with the XML files.
+#       Currently, the available additional outputs are json and
+#       ext_json. At most one add_output can be set.
+#
+# add_output json;
+
+
 # pid_file
 #
 #	filename where DSC should store its process-id

--- a/collector/dsc/md_array.c
+++ b/collector/dsc/md_array.c
@@ -7,7 +7,6 @@
 #include <syslog.h>
 
 #include "xmalloc.h"
-#include "dataset_opt.h"
 #include "md_array.h"
 #include "dns_message.h"
 #include "pcap.h"
@@ -214,7 +213,7 @@ md_array_print(md_array * a, md_array_printer * pr, FILE * fp)
 	nvals = a->d2.alloc_sz;
 	sortme = xcalloc(nvals, sizeof(*sortme));
 	if (NULL == sortme) {
-	    syslog(LOG_CRIT, "%s", "Cant output XML file chunk due to malloc failure!");
+	    syslog(LOG_CRIT, "%s", "Cant output file chunk due to malloc failure!");
 	    continue;		/* OUCH! */
 	}
 	while ((i2 = a->d2.indexer->iter_fn(&label2)) > -1) {

--- a/collector/dsc/md_array.h
+++ b/collector/dsc/md_array.h
@@ -1,4 +1,6 @@
-
+#ifndef MD_ARRAY_H
+#define MD_ARRAY_H
+#include "dataset_opt.h"
 
 typedef struct _md_array md_array;
 typedef struct _md_array_printer md_array_printer;
@@ -80,3 +82,5 @@ md_array *md_array_create(const char *name, filter_list *, const char *, indexer
 int md_array_print(md_array * a, md_array_printer * pr, FILE * fp);
 filter_list **md_array_filter_list_append(filter_list ** fl, FLTR * f);
 FLTR *md_array_create_filter(const char *name, filter_func *, const void *context);
+
+#endif

--- a/collector/dsc/md_array_json_printer.c
+++ b/collector/dsc/md_array_json_printer.c
@@ -1,0 +1,196 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#include "dns_message.h"
+#include "md_array.h"
+#include "pcap.h"
+#include "base64.h"
+#include "xmalloc.h"
+
+const int date_size = 255;
+
+static const char *d1_type_s;	/* XXX barf */
+static const char *d2_type_s;	/* XXX barf */
+
+static char comma[3] = { 0 };	/* Comma-separators manager  */
+
+static void
+start_array_json(void *pr_data, const char *name)
+{
+    FILE *fp = pr_data;
+    assert(fp);
+
+    char buff[date_size];
+
+    if (comma[0]) {
+	fprintf(fp, ",\n");
+    } else {
+	comma[0] = 1;
+    }
+    fprintf(fp, "  ");
+
+    fprintf(fp, "\"%s\": {\n", name);
+    Pcap_start_time_iso8601(buff, date_size);
+    fprintf(fp, "    \"start_time\": \"%s\",\n", buff);
+    Pcap_finish_time_iso8601(buff, date_size);
+    fprintf(fp, "    \"stop_time\": \"%s\",\n", buff);
+    fprintf(fp, "    \"dimensions\": [");
+}
+
+static void
+start_array_ext_json(void *pr_data, const char *name)
+{
+    FILE *fp = pr_data;
+    assert(fp);
+
+    if (comma[0]) {
+	fprintf(fp, ",\n");
+    } else {
+	comma[0] = 1;
+    }
+    fprintf(fp, "  ");
+
+    fprintf(fp, "\"%s\": {\n", name);
+    fprintf(fp, "    \"start_time\": { \"$date\": %d000 },\n", Pcap_start_time());
+    fprintf(fp, "    \"stop_time\": { \"$date\": %d000 },\n", Pcap_finish_time());
+    fprintf(fp, "    \"dimensions\": [");
+}
+
+static void
+finish_array(void *pr_data)
+{
+    FILE *fp = pr_data;
+    comma[1] = 0;
+    fprintf(fp, "  }");
+}
+
+static void
+d1_type(void *pr_data, const char *t)
+{
+    FILE *fp = pr_data;
+    fprintf(fp, " \"%s\"", t);
+    d1_type_s = t;
+}
+
+static void
+d2_type(void *pr_data, const char *t)
+{
+    FILE *fp = pr_data;
+    fprintf(fp, ", \"%s\" ],\n", t);
+    d2_type_s = t;
+}
+
+static const char *entity_chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz" "0123456789._-:";
+
+static void
+d1_begin(void *pr_data, char *l)
+{
+    FILE *fp = pr_data;
+    int ll = strlen(l);
+    char *e = NULL;
+    if (strspn(l, entity_chars) != ll) {
+	int x = base64_encode(l, ll, &e);
+	assert(x);
+	l = e;
+    }
+
+    comma[2] = 0;
+    if (comma[1]) {
+	fprintf(fp, ",\n");
+    } else {
+	fprintf(fp, "\n");
+	comma[1] = 1;
+    }
+
+    fprintf(fp, "      {\n");
+    fprintf(fp, "        ");
+    fprintf(fp, "\"%s\": \"%s\",\n", d1_type_s, l);
+    fprintf(fp, "        ");
+    fprintf(fp, "\"%s\": [", d2_type_s);
+
+    if (e)
+	xfree(e);
+}
+
+static void
+print_element(void *pr_data, char *l, int val)
+{
+    FILE *fp = pr_data;
+    int ll = strlen(l);
+    char *e = NULL;
+    if (strspn(l, entity_chars) != ll) {
+	int x = base64_encode(l, ll, &e);
+	assert(x);
+	l = e;
+    }
+
+    if (comma[2]) {
+	fprintf(fp, ",");
+    } else {
+	comma[2] = 1;
+    }
+    fprintf(fp, "\n          ");
+    fprintf(fp, "{ \"val\": \"%s\", \"count\": %d }", l, val);
+
+    if (e)
+	xfree(e);
+}
+
+static void
+d1_end(void *pr_data, char *l)
+{
+    FILE *fp = pr_data;
+
+    if (comma[2]) {
+	fprintf(fp, "\n        ]");
+    } else {
+	fprintf(fp, " ]");
+    }
+
+    fprintf(fp, "\n      }");
+}
+
+static void
+start_data(void *pr_data)
+{
+    FILE *fp = pr_data;
+    fprintf(fp, "    \"data\": [");
+}
+
+static void
+finish_data(void *pr_data)
+{
+    FILE *fp = pr_data;
+
+    if (comma[1]) {
+	fprintf(fp, "\n    ]\n");
+    } else {
+	fprintf(fp, " ]\n");
+    }
+}
+
+md_array_printer json_printer = {
+    start_array_json,
+    finish_array,
+    d1_type,
+    d2_type,
+    start_data,
+    finish_data,
+    d1_begin,
+    d1_end,
+    print_element
+};
+
+md_array_printer ext_json_printer = {
+    start_array_ext_json,
+    finish_array,
+    d1_type,
+    d2_type,
+    start_data,
+    finish_data,
+    d1_begin,
+    d1_end,
+    print_element
+};

--- a/collector/dsc/pcap.c
+++ b/collector/dsc/pcap.c
@@ -901,6 +901,27 @@ Pcap_finish_time(void)
 }
 
 void
+time_t_to_iso8601(char *buff, int size, time_t secs)
+{
+    time_t clone_t = secs;
+    memset(buff, 0, size);
+    struct tm *tm = gmtime(&clone_t);
+    strftime(buff, size, "%FT%TZ", tm);
+}
+
+void
+Pcap_start_time_iso8601(char *buff, int size)
+{
+    return time_t_to_iso8601(buff, size, start_ts.tv_sec);
+}
+
+void
+Pcap_finish_time_iso8601(char *buff, int size)
+{
+    return time_t_to_iso8601(buff, size, finish_ts.tv_sec);
+}
+
+void
 pcap_set_match_vlan(int vlan)
 {
     assert(n_vlan_ids < MAX_VLAN_IDS);
@@ -909,11 +930,8 @@ pcap_set_match_vlan(int vlan)
 
 /* ========== PCAP_STAT INDEXER ========== */
 
-#include "md_array.h"
-
 int pcap_ifname_iterator(char **);
 int pcap_stat_iterator(char **);
-extern md_array_printer xml_printer;
 
 static indexer_t indexers[] = {
     {"ifname", NULL, pcap_ifname_iterator, NULL},
@@ -956,7 +974,7 @@ pcap_stat_iterator(char **label)
 }
 
 void
-pcap_report(FILE * fp)
+pcap_report(FILE * fp, md_array_printer * printer)
 {
     int i;
     md_array *theArray = acalloc(1, sizeof(*theArray));
@@ -976,5 +994,5 @@ pcap_report(FILE * fp)
 	theArray->array[i].array[1] = I->ps1.ps_recv - I->ps0.ps_recv;
 	theArray->array[i].array[2] = I->ps1.ps_drop - I->ps0.ps_drop;
     }
-    md_array_print(theArray, &xml_printer, fp);
+    md_array_print(theArray, printer, fp);
 }

--- a/collector/dsc/pcap.h
+++ b/collector/dsc/pcap.h
@@ -1,7 +1,10 @@
+#include "md_array.h"
 
 void Pcap_init(const char *device, int promisc);
 int Pcap_run();
 void Pcap_close(void);
 int Pcap_start_time(void);
 int Pcap_finish_time(void);
-void pcap_report(FILE *);
+void Pcap_start_time_iso8601(char *, int);
+void Pcap_finish_time_iso8601(char *, int);
+void pcap_report(FILE *, md_array_printer*);


### PR DESCRIPTION
* Add a new option 'add_output' in the config file. Possible values are json and ext_json
* add_output can only be set once in the config file
* 'add_output json' dates comply to iso8601
* 'add_output ext_json' dates comply to the format specified for Extended JSON (MongoDB related)