### PR TITLE
fix ipv6 hash collision using client ip net.

### DIFF
--- a/src/client_ip_net_index.c
+++ b/src/client_ip_net_index.c
@@ -133,7 +133,7 @@ static unsigned int
 ipnet_hashfunc(const void *key)
 {
     const inX_addr *a = key;
-    return inXaddr_hash(a);
+    return ntohl(a->_.pad1.s_addr) + ntohl(a->_.in4.s_addr);
 }
 
 static int

--- a/src/inX_addr.c
+++ b/src/inX_addr.c
@@ -77,7 +77,7 @@ unsigned int
 inXaddr_hash(const inX_addr * a)
 {
     /* just ignore the upper bits for v6? */
-    return ntohl(a->_.in4.s_addr);
+    return ntohl(a->_.pad1.s_addr) + ntohl(a->_.in4.s_addr);
 }
 
 int

--- a/src/inX_addr.c
+++ b/src/inX_addr.c
@@ -77,7 +77,7 @@ unsigned int
 inXaddr_hash(const inX_addr * a)
 {
     /* just ignore the upper bits for v6? */
-    return ntohl(a->_.pad1.s_addr) + ntohl(a->_.in4.s_addr);
+    return ntohl(a->_.in4.s_addr);
 }
 
 int


### PR DESCRIPTION
Client ip net module is masked by /96 for IPv6, but inXaddr_hash uses only low-order 32 bits.
