### PR TITLE
Update daemon.c

### DIFF
--- a/src/daemon.c
+++ b/src/daemon.c
@@ -359,7 +359,7 @@ main(int argc, char *argv[])
     pthread_t sigthread;
 #endif
 
-    progname = xstrdup(strrchr(argv[0], '/') ? strchr(argv[0], '/') + 1 : argv[0]);
+    progname = xstrdup(strrchr(argv[0], '/') ? strrchr(argv[0], '/') + 1 : argv[0]);
     if (NULL == progname)
         return 1;
     srandom(time(NULL));


### PR DESCRIPTION
At the moment, if dsc is started from the path "/usr/bin/dsc", then "progname" contains "usr/bin/dsc", but this is incorrect. It should evaluate to "dsc". This PR fixes this little buglet.