### PR TITLE
Drop IP fragments

### DIFF
--- a/src/config_hooks.c
+++ b/src/config_hooks.c
@@ -71,6 +71,7 @@ int geoip_asn_v6_options = 0;
 int pcap_buffer_size = 0;
 int no_wait_interval = 0;
 int pt_timeout = 100;
+int drop_ip_fragments = 0;
 
 int
 open_interface(const char *interface)
@@ -352,4 +353,12 @@ set_pt_timeout(const char *s)
         return 0;
     }
     return 1;
+}
+
+void
+set_drop_ip_fragments(void)
+{
+    dsyslog(LOG_INFO, "dropping ip fragments");
+
+    drop_ip_fragments = 1;
 }

--- a/src/config_hooks.h
+++ b/src/config_hooks.h
@@ -56,5 +56,6 @@ int set_geoip_asn_v6_dat(const char * dat, int options);
 int set_pcap_buffer_size(const char *s);
 void set_no_wait_interval(void);
 int set_pt_timeout(const char *s);
+void set_drop_ip_fragments(void);
 
 #endif /* __dsc_config_hooks_h */

--- a/src/dsc.conf.5.in
+++ b/src/dsc.conf.5.in
@@ -50,7 +50,7 @@ version 2.2.0, a configuration line may not be divided with CR/LF and
 quoted characters are not understood (\\quote).
 .SH CONFIGURATION
 .TP
-\fBlocal_address\fR IP [ MASK / BITS ];
+\fBlocal_address\fR IP [ MASK / BITS ] ;
 Specifies the DNS server's local IP address with an optional mask/bits
 for local networks.  It is used to determine the direction of an IP packet:
 sending, receiving, or other.  You may specify multiple local addresses
@@ -103,7 +103,7 @@ makes only one pass through
 the configuration file and the BPF filter is set when the
 interface is initialized.
 .TP
-\fBpcap_buffer_size\fR NUMBER;
+\fBpcap_buffer_size\fR NUMBER ;
 Set the buffer size (in bytes) for pcap, increasing this may help
 if you see dropped packets by the kernel but increasing it too much
 may have other side effects.
@@ -115,9 +115,15 @@ makes only one pass through
 the configuration file and the pcap buffer size is set when the
 interface is initialized.
 .TP
-\fBpcap_thread_timeout\fR MILLISECONDS;
+\fBpcap_thread_timeout\fR MILLISECONDS ;
 Set the internal timeout pcap-thread uses when waiting for packets, the
 default is 100 ms.
+
+Note that this directive must go before the \fBinterface\fR
+directive.
+.TP
+\fBdrop_ip_fragments\fR ;
+Drop all packets that are fragments.
 
 Note that this directive must go before the \fBinterface\fR
 directive.
@@ -708,6 +714,7 @@ pid_file "/run/dsc.pid";
 
 #pcap_buffer_size 4194304;
 #pcap_thread_timeout 100;
+#drop_ip_fragments;
 interface eth0;
 
 dataset qtype dns All:null Qtype:qtype queries-only;

--- a/src/dsc.conf.sample.in
+++ b/src/dsc.conf.sample.in
@@ -63,6 +63,13 @@ pid_file "@DSC_PID_FILE@";
 #  NOTE: pcap_thread_timeout must GO BEFORE interface
 #pcap_thread_timeout 100;
 
+# drop_ip_fragments
+#
+#  Drop all packets that are fragments
+#
+#  NOTE: drop_ip_fragments must GO BEFORE interface
+#drop_ip_fragments;
+
 # interface
 #
 #  specifies a network interface to sniff packets from or a pcap

--- a/src/parse_conf.c
+++ b/src/parse_conf.c
@@ -546,6 +546,11 @@ int parse_conf_pcap_thread_timeout(const conf_token_t* tokens) {
     return ret == 1 ? 0 : 1;
 }
 
+int parse_conf_drop_ip_fragments(const conf_token_t* tokens) {
+    set_drop_ip_fragments();
+    return 0;
+}
+
 static conf_token_syntax_t _syntax[] = {
     {
         "interface",
@@ -646,6 +651,11 @@ static conf_token_syntax_t _syntax[] = {
         "pcap_thread_timeout",
         parse_conf_pcap_thread_timeout,
         { TOKEN_NUMBER, TOKEN_END }
+    },
+    {
+        "drop_ip_fragments",
+        parse_conf_drop_ip_fragments,
+        { TOKEN_END }
     },
 
     { 0, 0, { TOKEN_END } }

--- a/src/pcap.c
+++ b/src/pcap.c
@@ -899,11 +899,12 @@ Pcap_init(const char *device, int promisc, int monitor, int immediate, int threa
     }
 
     if (0 == n_interfaces) {
+        extern int drop_ip_fragments;
         /*
          * Initialize pcap_layers library and specifiy IP fragment reassembly
          * Datalink type is handled in callback
          */
-        pcap_layers_init(DLT_EN10MB, 1);
+        pcap_layers_init(DLT_EN10MB, drop_ip_fragments ? 0 : 1);
         if (n_vlan_ids)
             callback_vlan = pcap_match_vlan;
         callback_ipv4 = pcap_ipv4_handler;


### PR DESCRIPTION
- Issue #146: add conf option `drop_ip_fragments` to control IP
  fragmentation reassembly within pcap_layers
- Fix spacing in conf man-page