### PR TITLE
Support the linux cooked sll frame

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -63,7 +63,7 @@ AC_CHECK_HEADERS([arpa/nameser_compat.h arpa/inet.h fcntl.h memory.h])
 AC_CHECK_HEADERS([netdb.h netinet/in.h stdint.h stdlib.h string.h])
 AC_CHECK_HEADERS([strings.h sys/mount.h sys/param.h sys/socket.h])
 AC_CHECK_HEADERS([sys/statfs.h sys/statvfs.h sys/time.h syslog.h])
-AC_CHECK_HEADERS([unistd.h netinet/ip_compat.h])
+AC_CHECK_HEADERS([unistd.h netinet/ip_compat.h pcap/sll.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST

--- a/src/pcap.c
+++ b/src/pcap.c
@@ -742,7 +742,9 @@ void handle_loop(const u_char* pkt, int len, void* userdata);
 void handle_raw(const u_char* pkt, int len, void* userdata);
 #endif
 void handle_ether(const u_char* pkt, int len, void* userdata);
-void handle_linux_sll(const u_char* pkt, int len, void* userdata);
+#ifdef DLT_LINUX_SLL
+void handle_linux_sll(const u_char * pkt, int len, void *userdata);
+#endif
 
 static void
 pcap_handle_packet(u_char* udata, const struct pcap_pkthdr* hdr, const u_char* pkt, const char* name, int dlt)
@@ -781,14 +783,14 @@ pcap_handle_packet(u_char* udata, const struct pcap_pkthdr* hdr, const u_char* p
         handle_datalink = handle_raw;
         break;
 #endif
-    case DLT_NULL:
-        handle_datalink = handle_null;
-        break;
-#ifdef linux
+#ifdef DLT_LINUX_SLL
     case DLT_LINUX_SLL:
         handle_datalink = handle_linux_sll;
         break;
 #endif
+    case DLT_NULL:
+        handle_datalink = handle_null;
+        break;
     default:
         fprintf(stderr, "unsupported data link type %d", dlt);
         exit(1);

--- a/src/pcap.c
+++ b/src/pcap.c
@@ -742,6 +742,7 @@ void handle_loop(const u_char* pkt, int len, void* userdata);
 void handle_raw(const u_char* pkt, int len, void* userdata);
 #endif
 void handle_ether(const u_char* pkt, int len, void* userdata);
+void handle_linux_sll(const u_char* pkt, int len, void* userdata);
 
 static void
 pcap_handle_packet(u_char* udata, const struct pcap_pkthdr* hdr, const u_char* pkt, const char* name, int dlt)
@@ -783,6 +784,11 @@ pcap_handle_packet(u_char* udata, const struct pcap_pkthdr* hdr, const u_char* p
     case DLT_NULL:
         handle_datalink = handle_null;
         break;
+#ifdef linux
+    case DLT_LINUX_SLL:
+        handle_datalink = handle_linux_sll;
+        break;
+#endif
     default:
         fprintf(stderr, "unsupported data link type %d", dlt);
         exit(1);


### PR DESCRIPTION
In relation to pcap_layers linux cooked sll support,
make dsc able to capture traffic for any interfaces.