### PR TITLE
MaxMind DB (GeoIP2)

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -6,8 +6,10 @@ extraction:
         - automake
         - autoconf
         - libtool
+        - pkg-config
         - libpcap-dev
         - libgeoip-dev
+        - libmaxminddb-dev
     configure:
       command:
         - ./autogen.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 addons:
   apt:
     update: true
@@ -5,6 +6,7 @@ addons:
     - libpcap-dev
     - libproc-pid-file-perl
     - libgeoip-dev
+    - libmaxminddb-dev
 language: c
 compiler:
   - clang

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Mailinglist:
 ## Dependencies
 
 `dsc` requires a couple of libraries beside a normal C compiling
-environment with autoconf, automake and libtool.
+environment with autoconf, automake, libtool and pkgconfig.
 
 `dsc` has a non-optional dependency on the PCAP library and optional
 dependency on the GeoIP library (for the `asn` and `country` indexer).
@@ -68,8 +68,8 @@ make install
 
 If you are building `dsc` from it's Git repository you will first need
 to initiate the Git submodules that exists and later create autoconf/automake
-files, this will require a build environment with autoconf, automake and
-libtool to be installed.
+files, this will require a build environment with autoconf, automake, libtool
+and pkgconfig to be installed.
 
 ```
 git clone https://github.com/DNS-OARC/dsc.git

--- a/configure.ac
+++ b/configure.ac
@@ -42,6 +42,7 @@ AC_CONFIG_HEADER([src/config.h])
 AC_PROG_CC
 AM_PROG_CC_C_O
 AC_PROG_INSTALL
+PKG_PROG_PKG_CONFIG
 
 # Check --enable-warn-all
 AC_ARG_ENABLE([warn-all], [AS_HELP_STRING([--enable-warn-all], [Enable all compiler warnings])], [AX_CFLAGS_WARN_ALL()])
@@ -60,16 +61,17 @@ AC_ARG_WITH([extra-ldflags], [AS_HELP_STRING([--with-extra-ldflags=CFLAGS], [Add
 
 # pcap thread
 AC_ARG_ENABLE(threads,
-    [AS_HELP_STRING([--enable-threads],
-        [enable the usage of threads (default disabled)])],
-    [AX_PCAP_THREAD],
-    [AX_PCAP_THREAD_PCAP])
+  [AS_HELP_STRING([--enable-threads],
+    [enable the usage of threads (default disabled)])],
+  [AX_PCAP_THREAD],
+  [AX_PCAP_THREAD_PCAP])
 
 # Checks for libraries.
 AC_CHECK_LIB([resolv], [inet_aton])
 AC_CHECK_LIB([nsl], [gethostbyname])
 AC_CHECK_LIB([socket], [connect])
 AC_CHECK_LIB([GeoIP], [GeoIP_open])
+PKG_CHECK_MODULES([libmaxminddb], [libmaxminddb], [AC_DEFINE([HAVE_LIBMAXMINDDB], [1], [Define to 1 if you have libmaxminddb.])], [:])
 
 # Checks for header files.
 AC_HEADER_STDC
@@ -79,6 +81,7 @@ AC_CHECK_HEADERS([netdb.h netinet/in.h stdint.h stdlib.h string.h])
 AC_CHECK_HEADERS([strings.h sys/mount.h sys/param.h sys/socket.h])
 AC_CHECK_HEADERS([sys/statfs.h sys/statvfs.h sys/time.h syslog.h])
 AC_CHECK_HEADERS([unistd.h netinet/ip_compat.h pcap/sll.h])
+AC_CHECK_HEADERS([GeoIP.h maxminddb.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST
@@ -107,27 +110,25 @@ AC_CHECK_FUNCS([strdup strerror strrchr strspn strstr strtoull statvfs])
 
 # pid file
 AC_ARG_WITH(pid-file,
-    [AS_HELP_STRING([--with-pid-file=FILE],
-        [write pid to FILE [/run/dsc.pid]])],
-    [],
-    [with_pid_file=/run/dsc.pid])
+  [AS_HELP_STRING([--with-pid-file=FILE], [write pid to FILE [/run/dsc.pid]])],
+  [],
+  [with_pid_file=/run/dsc.pid])
 
 AC_SUBST([DSC_PID_FILE], [$with_pid_file])
 
 # data dir
 AC_ARG_WITH(data-dir,
-    [AS_HELP_STRING([--with-data-dir=DIR],
-        [use DIR for DSC data [LOCALSTATEDIR/lib/dsc]])],
-    [],
-    [with_data_dir=${localstatedir}/lib/dsc])
+  [AS_HELP_STRING([--with-data-dir=DIR], [use DIR for DSC data [LOCALSTATEDIR/lib/dsc]])],
+  [],
+  [with_data_dir=${localstatedir}/lib/dsc])
 
 AC_SUBST([DSC_DATA_DIR], [$with_data_dir])
 
 # Generate
 AC_CONFIG_FILES([
-    Makefile
-    src/Makefile
-    src/test/Makefile
-    cron/Makefile
+  Makefile
+  src/Makefile
+  src/test/Makefile
+  cron/Makefile
 ])
 AC_OUTPUT

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,8 @@ Section: net
 Priority: optional
 Maintainer: Jerry Lundström <lundstrom.jerry@gmail.com>
 Build-Depends: debhelper (>= 8.0.0), build-essential, automake, autoconf,
- libpcap-dev, libproc-pid-file-perl, netbase, libgeoip-dev
+ libpcap-dev, libproc-pid-file-perl, netbase, libgeoip-dev, pkg-config,
+ libmaxminddb-dev
 Standards-Version: 3.9.4
 Homepage: https://www.dns-oarc.net/oarc/data/dsc
 Vcs-Git: https://github.com/DNS-OARC/dsc.git

--- a/rpm/dsc.spec
+++ b/rpm/dsc.spec
@@ -12,11 +12,13 @@ Source0:        %{name}_%{version}.orig.tar.gz
 
 BuildRequires:  libpcap-devel
 BuildRequires:  GeoIP-devel
+BuildRequires:  libmaxminddb-devel
 BuildRequires:  perl
 BuildRequires:  perl(Proc::PID::File)
 BuildRequires:  autoconf
 BuildRequires:  automake
 BuildRequires:  libtool
+BuildRequires:  pkgconfig
 Requires:       perl
 Requires:       perl(Proc::PID::File)
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -6,7 +6,8 @@ SUBDIRS = test
 AM_CFLAGS = -I$(srcdir) \
     -Wall \
     -DUSE_IPV6=1 \
-    $(PTHREAD_CFLAGS)
+    $(PTHREAD_CFLAGS) \
+    $(libmaxminddb_CFLAGS)
 
 EXTRA_DIST = dsc.sh \
     dsc.conf.sample.in \
@@ -110,8 +111,9 @@ dist_dsc_SOURCES = base64.h \
     pcap-thread/pcap_thread.h \
     parse_conf.h \
     config_hooks.h \
-    compat.h
-dsc_LDADD = $(PTHREAD_LIBS)
+    compat.h \
+    geoip.h
+dsc_LDADD = $(PTHREAD_LIBS) $(libmaxminddb_LIBS)
 man1_MANS = dsc.1
 man5_MANS = dsc.conf.5
 

--- a/src/asn_index.c
+++ b/src/asn_index.c
@@ -36,40 +36,50 @@
 
 #include "config.h"
 
-#if HAVE_LIBGEOIP
-
 #include <stdlib.h>
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
-#include <GeoIP.h>
+#include <netinet/in.h>
+#include <inttypes.h>
 
 #include "xmalloc.h"
 #include "dns_message.h"
 #include "md_array.h"
 #include "hashtbl.h"
 #include "syslog_debug.h"
+#include "geoip.h"
+#include "compat.h"
+#include "errno.h"
 
-extern int        debug_flag;
-extern char*      geoip_asn_v4_dat;
-extern int        geoip_asn_v4_options;
-extern char*      geoip_asn_v6_dat;
-extern int        geoip_asn_v6_options;
-static hashfunc   asn_hashfunc;
-static hashkeycmp asn_cmpfunc;
+extern int                debug_flag;
+extern char*              geoip_asn_v4_dat;
+extern int                geoip_asn_v4_options;
+extern char*              geoip_asn_v6_dat;
+extern int                geoip_asn_v6_options;
+extern enum geoip_backend asn_indexer_backend;
+extern char*              maxminddb_asn;
+static hashfunc           asn_hashfunc;
+static hashkeycmp         asn_cmpfunc;
 
 #define MAX_ARRAY_SZ 65536
 static hashtbl* theHash  = NULL;
 static int      next_idx = 0;
-static GeoIP*   geoip    = NULL;
-static GeoIP*   geoip6   = NULL;
-static char     ipstr[81];
-static char*    nodb       = "NODB";
-static char*    unknown    = "??";
-static char*    unknown_v4 = "?4";
-static char*    unknown_v6 = "?6";
-static char*    _asn       = NULL;
+#ifdef HAVE_GEOIP
+static GeoIP* geoip  = NULL;
+static GeoIP* geoip6 = NULL;
+#endif
+#ifdef HAVE_MAXMINDDB
+static MMDB_s mmdb;
+static char   _mmasn[32];
+#endif
+static char  ipstr[81];
+static char* nodb       = "NODB";
+static char* unknown    = "??";
+static char* unknown_v4 = "?4";
+static char* unknown_v6 = "?6";
+static char* _asn       = NULL;
 
 typedef struct {
     char* asn;
@@ -80,16 +90,16 @@ const char*
 asn_get_from_message(dns_message* m)
 {
     transport_message* tm;
-    char*              asn;
-    char*              truncate;
+    const char*        asn = unknown;
 
     tm = m->tm;
 
-    if (!inXaddr_ntop(&tm->src_ip_addr, ipstr, sizeof(ipstr) - 1)) {
-        dfprint(0, "asn_index: Error converting IP address");
-        return unknown;
+    if (asn_indexer_backend == geoip_backend_libgeoip) {
+        if (!inXaddr_ntop(&tm->src_ip_addr, ipstr, sizeof(ipstr) - 1)) {
+            dfprint(0, "asn_index: Error converting IP address");
+            return unknown;
+        }
     }
-    dfprintf(0, "asn_index: IP %s is IPv%d", ipstr, tm->ip_version);
 
     if (_asn) {
         free(_asn);
@@ -98,47 +108,152 @@ asn_get_from_message(dns_message* m)
 
     switch (tm->ip_version) {
     case 4:
-        if (geoip) {
-            if ((_asn = GeoIP_name_by_addr(geoip, ipstr))) {
-                asn = _asn;
+        switch (asn_indexer_backend) {
+        case geoip_backend_libgeoip:
+#ifdef HAVE_GEOIP
+            if (geoip) {
+                if ((_asn = GeoIP_name_by_addr(geoip, ipstr))) {
+                    /* libgeoip reports for networks with the same ASN different network names.
+                     * Probably it uses the network description, not the AS description. Therefore,
+                     * we truncate after the first space and only use the AS number. Mappings
+                     * to AS names must be done in the presenter.
+                     */
+                    char* truncate = strchr(_asn, ' ');
+                    if (truncate) {
+                        *truncate = 0;
+                    }
+                    asn = _asn;
+                } else {
+                    asn = unknown_v4;
+                }
+            } else {
+                asn = nodb;
+            }
+#endif
+            break;
+        case geoip_backend_libmaxminddb: {
+#ifdef HAVE_MAXMINDDB
+            struct sockaddr_in   s;
+            int                  ret;
+            MMDB_lookup_result_s r;
+
+            s.sin_family = AF_INET;
+            s.sin_addr   = tm->src_ip_addr._.in4;
+
+            r = MMDB_lookup_sockaddr(&mmdb, (struct sockaddr*)&s, &ret);
+            if (ret == MMDB_SUCCESS && r.found_entry) {
+                MMDB_entry_data_s entry_data;
+
+                if (MMDB_get_value(&r.entry, &entry_data, "autonomous_system_number", 0) == MMDB_SUCCESS) {
+                    switch (entry_data.type) {
+                    case MMDB_DATA_TYPE_UINT16:
+                        snprintf(_mmasn, sizeof(_mmasn), "%" PRIu16, entry_data.uint16);
+                        asn = _mmasn;
+                        break;
+                    case MMDB_DATA_TYPE_UINT32:
+                        snprintf(_mmasn, sizeof(_mmasn), "%" PRIu32, entry_data.uint32);
+                        asn = _mmasn;
+                        break;
+                    case MMDB_DATA_TYPE_INT32:
+                        snprintf(_mmasn, sizeof(_mmasn), "%" PRId32, entry_data.int32);
+                        asn = _mmasn;
+                        break;
+                    case MMDB_DATA_TYPE_UINT64:
+                        snprintf(_mmasn, sizeof(_mmasn), "%" PRIu64, entry_data.uint64);
+                        asn = _mmasn;
+                        break;
+                    default:
+                        dfprintf(1, "asn_index: found entry in MMDB but unknown type %u", entry_data.type);
+                        asn = unknown_v4;
+                    }
+                }
             } else {
                 asn = unknown_v4;
             }
-        } else {
-            asn = nodb;
+#endif
+            break;
+        }
+        default:
+            break;
         }
         break;
 
     case 6:
-        if (geoip6) {
-            if ((_asn = GeoIP_name_by_addr_v6(geoip6, ipstr))) {
-                asn = _asn;
+        switch (asn_indexer_backend) {
+        case geoip_backend_libgeoip:
+#ifdef HAVE_GEOIP
+            if (geoip6) {
+                if ((_asn = GeoIP_name_by_addr_v6(geoip6, ipstr))) {
+                    /* libgeoip reports for networks with the same ASN different network names.
+                     * Probably it uses the network description, not the AS description. Therefore,
+                     * we truncate after the first space and only use the AS number. Mappings
+                     * to AS names must be done in the presenter.
+                     */
+                    char* truncate = strchr(_asn, ' ');
+                    if (truncate) {
+                        *truncate = 0;
+                    }
+                    asn = _asn;
+                } else {
+                    asn = unknown_v6;
+                }
             } else {
-                asn = unknown_v6;
+                asn = nodb;
             }
+#endif
             break;
-        } else {
-            asn = nodb;
+        case geoip_backend_libmaxminddb: {
+#ifdef HAVE_MAXMINDDB
+            struct sockaddr_in6  s;
+            int                  ret;
+            MMDB_lookup_result_s r;
+
+            s.sin6_family = AF_INET;
+            s.sin6_addr   = tm->src_ip_addr.in6;
+
+            r = MMDB_lookup_sockaddr(&mmdb, (struct sockaddr*)&s, &ret);
+            if (ret == MMDB_SUCCESS && r.found_entry) {
+                MMDB_entry_data_s entry_data;
+
+                if (MMDB_get_value(&r.entry, &entry_data, "autonomous_system_number", 0) == MMDB_SUCCESS) {
+                    switch (entry_data.type) {
+                    case MMDB_DATA_TYPE_UINT16:
+                        snprintf(_mmasn, sizeof(_mmasn), "%" PRIu16, entry_data.uint16);
+                        asn = _mmasn;
+                        break;
+                    case MMDB_DATA_TYPE_UINT32:
+                        snprintf(_mmasn, sizeof(_mmasn), "%" PRIu32, entry_data.uint32);
+                        asn = _mmasn;
+                        break;
+                    case MMDB_DATA_TYPE_INT32:
+                        snprintf(_mmasn, sizeof(_mmasn), "%" PRId32, entry_data.int32);
+                        asn = _mmasn;
+                        break;
+                    case MMDB_DATA_TYPE_UINT64:
+                        snprintf(_mmasn, sizeof(_mmasn), "%" PRIu64, entry_data.uint64);
+                        asn = _mmasn;
+                        break;
+                    default:
+                        dfprintf(1, "asn_index: found entry in MMDB but unknown type %u", entry_data.type);
+                        asn = unknown_v4;
+                    }
+                }
+            } else {
+                asn = unknown_v4;
+            }
+#endif
+            break;
+        }
+        default:
+            break;
         }
         break;
 
     default:
-        asn = unknown;
+        break;
     }
 
-    dfprintf(0, "asn_index: full network name: %s", asn);
-
-    /* libgeoip reports for networks with the same ASN different network names.
-     * Probably it uses the network description, not the AS description. Therefore,
-     * we truncate after the first space and only use the AS number. Mappings
-     * to AS names must be done in the presenter.
-     */
-    truncate = strchr(asn, ' ');
-    if (truncate) {
-        *truncate = 0;
-    }
-
-    dfprintf(0, "asn_index: truncated network name: %s", asn);
+    dfprintf(1, "asn_index: network name: %s", asn);
     return asn;
 }
 
@@ -225,26 +340,53 @@ asn_cmpfunc(const void* a, const void* b)
 
 void asn_indexer_init()
 {
-    if (geoip_asn_v4_dat) {
-        geoip = GeoIP_open(geoip_asn_v4_dat, geoip_asn_v4_options);
-        if (geoip == NULL) {
-            dsyslog(LOG_ERR, "asn_index: Error opening IPv4 ASNum DB. Make sure libgeoip's GeoIPASNum.dat file is available");
+    switch (asn_indexer_backend) {
+    case geoip_backend_libgeoip:
+#ifdef HAVE_GEOIP
+        if (geoip_asn_v4_dat) {
+            geoip = GeoIP_open(geoip_asn_v4_dat, geoip_asn_v4_options);
+            if (geoip == NULL) {
+                dsyslog(LOG_ERR, "asn_index: Error opening IPv4 ASNum DB. Make sure libgeoip's GeoIPASNum.dat file is available");
+                exit(1);
+            }
+        }
+        if (geoip_asn_v6_dat) {
+            geoip6 = GeoIP_open(geoip_asn_v6_dat, geoip_asn_v6_options);
+            if (geoip6 == NULL) {
+                dsyslog(LOG_ERR, "asn_index: Error opening IPv6 ASNum DB. Make sure libgeoip's GeoIPASNumv6.dat file is available");
+                exit(1);
+            }
+        }
+        memset(ipstr, 0, sizeof(ipstr));
+        if (geoip || geoip6) {
+            dsyslog(LOG_INFO, "asn_index: Sucessfully initialized GeoIP ASN");
+        } else {
+            dsyslog(LOG_INFO, "asn_index: No database loaded for GeoIP ASN");
+        }
+#endif
+        break;
+    case geoip_backend_libmaxminddb: {
+#ifdef HAVE_MAXMINDDB
+        int  ret;
+        char errbuf[512];
+
+        if (!maxminddb_asn) {
+            dsyslog(LOG_ERR, "asn_index: Error no MaxMind ASN DB configured");
             exit(1);
         }
-    }
-    if (geoip_asn_v6_dat) {
-        geoip6 = GeoIP_open(geoip_asn_v6_dat, geoip_asn_v6_options);
-        if (geoip6 == NULL) {
-            dsyslog(LOG_ERR, "asn_index: Error opening IPv6 ASNum DB. Make sure libgeoip's GeoIPASNumv6.dat file is available");
+        ret = MMDB_open(maxminddb_asn, 0, &mmdb);
+        if (ret == MMDB_IO_ERROR) {
+            dsyslogf(LOG_ERR, "asn_index: Error opening MaxMind ASN DB, IO error: %s", dsc_strerror(errno, errbuf, sizeof(errbuf)));
+            exit(1);
+        } else if (ret != MMDB_SUCCESS) {
+            dsyslogf(LOG_ERR, "asn_index: Error opening MaxMind ASN DB: %s", MMDB_strerror(ret));
             exit(1);
         }
+        dsyslog(LOG_INFO, "asn_index: Sucessfully initialized MaxMind ASN DB");
+#endif
+        break;
     }
-    memset(ipstr, 0, sizeof(ipstr));
-    if (geoip || geoip6) {
-        dsyslog(LOG_INFO, "asn_index: Sucessfully initialized GeoIP ASN");
-    } else {
-        dsyslog(LOG_INFO, "asn_index: No database loaded for GeoIP ASN");
+    default:
+        break;
     }
 }
-
-#endif

--- a/src/asn_index.h
+++ b/src/asn_index.h
@@ -37,10 +37,9 @@
 #ifndef __dsc_asn_index_h
 #define __dsc_asn_index_h
 
-/* check HAVE_LIBGEOIP before #including this file */
-
 int asn_indexer(const void*);
 int asn_iterator(char** label);
 void asn_reset(void);
+void asn_indexer_init();
 
 #endif /* __dsc_asn_index_h */

--- a/src/client_ip_net_index.h
+++ b/src/client_ip_net_index.h
@@ -40,6 +40,7 @@
 int cip_net_indexer(const void*);
 int cip_net_iterator(char** label);
 void cip_net_reset(void);
+void cip_net_indexer_init(void);
 int cip_net_v4_mask_set(const char* mask);
 int cip_net_v6_mask_set(const char* mask);
 

--- a/src/country_index.c
+++ b/src/country_index.c
@@ -36,37 +36,46 @@
 
 #include "config.h"
 
-#if HAVE_LIBGEOIP
-
 #include <stdlib.h>
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
-#include <GeoIP.h>
+#include <netinet/in.h>
 
 #include "xmalloc.h"
 #include "dns_message.h"
 #include "md_array.h"
 #include "hashtbl.h"
 #include "syslog_debug.h"
+#include "geoip.h"
+#include "compat.h"
+#include "errno.h"
 
-extern int        debug_flag;
-extern char*      geoip_v4_dat;
-extern int        geoip_v4_options;
-extern char*      geoip_v6_dat;
-extern int        geoip_v6_options;
-static hashfunc   country_hashfunc;
-static hashkeycmp country_cmpfunc;
+extern int                debug_flag;
+extern char*              geoip_v4_dat;
+extern int                geoip_v4_options;
+extern char*              geoip_v6_dat;
+extern int                geoip_v6_options;
+extern enum geoip_backend country_indexer_backend;
+extern char*              maxminddb_country;
+static hashfunc           country_hashfunc;
+static hashkeycmp         country_cmpfunc;
 
 #define MAX_ARRAY_SZ 65536
 static hashtbl* theHash  = NULL;
 static int      next_idx = 0;
-static GeoIP*   geoip    = NULL;
-static GeoIP*   geoip6   = NULL;
-static char     ipstr[81];
-static char*    unknown    = "??";
-static char*    unknown_v4 = "?4";
-static char*    unknown_v6 = "?6";
+#ifdef HAVE_GEOIP
+static GeoIP* geoip  = NULL;
+static GeoIP* geoip6 = NULL;
+#endif
+#ifdef HAVE_MAXMINDDB
+static MMDB_s mmdb;
+static char   _mmcountry[32];
+#endif
+static char  ipstr[81];
+static char* unknown    = "??";
+static char* unknown_v4 = "?4";
+static char* unknown_v6 = "?6";
 
 typedef struct
 {
@@ -78,39 +87,110 @@ const char*
 country_get_from_message(dns_message* m)
 {
     transport_message* tm;
-    const char*        cc;
+    const char*        cc = unknown;
 
     tm = m->tm;
-    if (!inXaddr_ntop(&tm->src_ip_addr, ipstr, sizeof(ipstr) - 1)) {
-        dfprint(0, "country_index: Error converting IP address");
-        return (unknown);
-    }
 
-    cc = unknown;
+    if (country_indexer_backend == geoip_backend_libgeoip) {
+        if (!inXaddr_ntop(&tm->src_ip_addr, ipstr, sizeof(ipstr) - 1)) {
+            dfprint(0, "country_index: Error converting IP address");
+            return (unknown);
+        }
+    }
 
     switch (tm->ip_version) {
     case 4:
-        if (geoip) {
-            cc = GeoIP_country_code_by_addr(geoip, ipstr);
-            if (cc == NULL) {
-                cc = unknown_v4;
+        switch (country_indexer_backend) {
+        case geoip_backend_libgeoip:
+#ifdef HAVE_GEOIP
+            if (geoip) {
+                cc = GeoIP_country_code_by_addr(geoip, ipstr);
+                if (cc == NULL) {
+                    cc = unknown_v4;
+                }
             }
+#endif
+            break;
+        case geoip_backend_libmaxminddb: {
+#ifdef HAVE_MAXMINDDB
+            struct sockaddr_in   s;
+            int                  ret;
+            MMDB_lookup_result_s r;
+
+            s.sin_family = AF_INET;
+            s.sin_addr   = tm->src_ip_addr._.in4;
+
+            r = MMDB_lookup_sockaddr(&mmdb, (struct sockaddr*)&s, &ret);
+            if (ret == MMDB_SUCCESS && r.found_entry) {
+                MMDB_entry_data_s entry_data;
+
+                if (MMDB_get_value(&r.entry, &entry_data, "country", "iso_code", 0) == MMDB_SUCCESS
+                    && entry_data.type == MMDB_DATA_TYPE_UTF8_STRING) {
+                    size_t len = entry_data.data_size > (sizeof(_mmcountry) - 1) ? (sizeof(_mmcountry) - 1) : entry_data.data_size;
+                    memcpy(_mmcountry, entry_data.utf8_string, len);
+                    _mmcountry[len] = 0;
+                    cc              = _mmcountry;
+                    break;
+                }
+            }
+            cc = unknown_v4;
+#endif
+            break;
+        }
+        default:
+            break;
         }
         break;
+
     case 6:
-        if (geoip6) {
-            cc = GeoIP_country_code_by_addr_v6(geoip6, ipstr);
-            if (cc == NULL) {
-                cc = unknown_v6;
+        switch (country_indexer_backend) {
+        case geoip_backend_libgeoip:
+#ifdef HAVE_GEOIP
+            if (geoip6) {
+                cc = GeoIP_country_code_by_addr_v6(geoip6, ipstr);
+                if (cc == NULL) {
+                    cc = unknown_v6;
+                }
             }
+#endif
+            break;
+        case geoip_backend_libmaxminddb: {
+#ifdef HAVE_MAXMINDDB
+            struct sockaddr_in6  s;
+            int                  ret;
+            MMDB_lookup_result_s r;
+
+            s.sin6_family = AF_INET;
+            s.sin6_addr   = tm->src_ip_addr.in6;
+
+            r = MMDB_lookup_sockaddr(&mmdb, (struct sockaddr*)&s, &ret);
+            if (ret == MMDB_SUCCESS && r.found_entry) {
+                MMDB_entry_data_s entry_data;
+
+                if (MMDB_get_value(&r.entry, &entry_data, "country", "iso_code", 0) == MMDB_SUCCESS
+                    && entry_data.type == MMDB_DATA_TYPE_UTF8_STRING) {
+                    size_t len = entry_data.data_size > (sizeof(_mmcountry) - 1) ? (sizeof(_mmcountry) - 1) : entry_data.data_size;
+                    memcpy(_mmcountry, entry_data.utf8_string, len);
+                    _mmcountry[len] = 0;
+                    cc              = _mmcountry;
+                    break;
+                }
+            }
+            cc = unknown_v6;
+#endif
+            break;
+        }
+        default:
+            break;
         }
         break;
+
     default:
         break;
     }
 
     dfprintf(1, "country_index: country code: %s", cc);
-    return (cc);
+    return cc;
 }
 
 int country_indexer(const void* vp)
@@ -184,26 +264,53 @@ country_cmpfunc(const void* a, const void* b)
 
 void country_indexer_init()
 {
-    if (geoip_v4_dat) {
-        geoip = GeoIP_open(geoip_v4_dat, geoip_v4_options);
-        if (geoip == NULL) {
-            dsyslog(LOG_ERR, "country_index: Error opening IPv4 Country DB. Make sure libgeoip's GeoIP.dat file is available");
+    switch (country_indexer_backend) {
+    case geoip_backend_libgeoip:
+#ifdef HAVE_GEOIP
+        if (geoip_v4_dat) {
+            geoip = GeoIP_open(geoip_v4_dat, geoip_v4_options);
+            if (geoip == NULL) {
+                dsyslog(LOG_ERR, "country_index: Error opening IPv4 Country DB. Make sure libgeoip's GeoIP.dat file is available");
+                exit(1);
+            }
+        }
+        if (geoip_v6_dat) {
+            geoip6 = GeoIP_open(geoip_v6_dat, geoip_v6_options);
+            if (geoip6 == NULL) {
+                dsyslog(LOG_ERR, "country_index: Error opening IPv6 Country DB. Make sure libgeoip's GeoIPv6.dat file is available");
+                exit(1);
+            }
+        }
+        memset(ipstr, 0, sizeof(ipstr));
+        if (geoip || geoip6) {
+            dsyslog(LOG_INFO, "country_index: Sucessfully initialized GeoIP");
+        } else {
+            dsyslog(LOG_INFO, "country_index: No database loaded for GeoIP");
+        }
+#endif
+        break;
+    case geoip_backend_libmaxminddb: {
+#ifdef HAVE_MAXMINDDB
+        int  ret;
+        char errbuf[512];
+
+        if (!maxminddb_country) {
+            dsyslog(LOG_ERR, "country_index: Error no MaxMind ASN DB configured");
             exit(1);
         }
-    }
-    if (geoip_v6_dat) {
-        geoip6 = GeoIP_open(geoip_v6_dat, geoip_v6_options);
-        if (geoip6 == NULL) {
-            dsyslog(LOG_ERR, "country_index: Error opening IPv6 Country DB. Make sure libgeoip's GeoIPv6.dat file is available");
+        ret = MMDB_open(maxminddb_country, 0, &mmdb);
+        if (ret == MMDB_IO_ERROR) {
+            dsyslogf(LOG_ERR, "country_index: Error opening MaxMind ASN DB, IO error: %s", dsc_strerror(errno, errbuf, sizeof(errbuf)));
+            exit(1);
+        } else if (ret != MMDB_SUCCESS) {
+            dsyslogf(LOG_ERR, "country_index: Error opening MaxMind ASN DB: %s", MMDB_strerror(ret));
             exit(1);
         }
+        dsyslog(LOG_INFO, "country_index: Sucessfully initialized MaxMind ASN DB");
+#endif
+        break;
     }
-    memset(ipstr, 0, sizeof(ipstr));
-    if (geoip || geoip6) {
-        dsyslog(LOG_INFO, "country_index: Sucessfully initialized GeoIP");
-    } else {
-        dsyslog(LOG_INFO, "country_index: No database loaded for GeoIP");
+    default:
+        break;
     }
 }
-
-#endif

--- a/src/country_index.h
+++ b/src/country_index.h
@@ -37,10 +37,9 @@
 #ifndef __dsc_country_index_h
 #define __dsc_country_index_h
 
-/* check HAVE_LIBGEOIP before #including this file */
-
 int country_indexer(const void*);
 int country_iterator(char** label);
 void country_reset(void);
+void country_indexer_init();
 
 #endif /* __dsc_country_index_h */

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -72,6 +72,9 @@
 #include "parse_conf.h"
 #include "compat.h"
 #include "pcap-thread/pcap_thread.h"
+#include "client_ip_net_index.h"
+#include "asn_index.h"
+#include "country_index.h"
 
 char* progname       = NULL;
 char* pid_file_name  = NULL;
@@ -83,11 +86,6 @@ int   debug_flag     = 0;
 int   nodaemon_flag  = 0;
 int   have_reports   = 0;
 
-extern void cip_net_indexer_init(void);
-#if HAVE_LIBGEOIP
-extern void country_indexer_init(void);
-extern void asn_indexer_init(void);
-#endif
 extern uint64_t         minfree_bytes;
 extern int              n_pcap_offline;
 extern md_array_printer xml_printer;
@@ -417,10 +415,8 @@ int main(int argc, char* argv[])
     if (parse_conf(argv[0])) {
         return 1;
     }
-#if HAVE_LIBGEOIP
     country_indexer_init();
     asn_indexer_init();
-#endif
     if (!output_format_xml && !output_format_json) {
         output_format_xml = 1;
     }

--- a/src/dns_message.c
+++ b/src/dns_message.c
@@ -34,6 +34,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "config.h"
+
 #include <stdlib.h>
 #include <assert.h>
 #include <stdio.h>
@@ -53,16 +55,13 @@
 #define T_A6 38
 #endif
 
-#include "config.h"
 #include "xmalloc.h"
 #include "dns_message.h"
 #include "null_index.h"
 #include "qtype_index.h"
 #include "qclass_index.h"
-#if HAVE_LIBGEOIP
 #include "country_index.h"
 #include "asn_index.h"
-#endif
 #include "tld_index.h"
 #include "rcode_index.h"
 #include "client_ip_addr_index.h"
@@ -272,10 +271,8 @@ servfail_filter(const void* vp, const void* ctx)
 static indexer_t indexers[] = {
     { "client", cip_indexer, cip_iterator, cip_reset },
     { "server", sip_indexer, sip_iterator, sip_reset },
-#if HAVE_LIBGEOIP
     { "country", country_indexer, country_iterator, country_reset },
     { "asn", asn_indexer, asn_iterator, asn_reset },
-#endif
     { "client_subnet", cip_net_indexer, cip_net_iterator, cip_net_reset },
     { "null", null_indexer, null_iterator, NULL },
     { "qclass", qclass_indexer, qclass_iterator, qclass_reset },

--- a/src/dsc.conf.5.in
+++ b/src/dsc.conf.5.in
@@ -192,6 +192,20 @@ GEOIP for options.
 Specify the GeoIP dat file to open for IPv6 AS number lookup, see section
 GEOIP for options.
 .TP
+\fBasn_indexer_backend\fR BACKEND ;
+Specify what backend to use for the ASN indexer, either "geoip" for GeoIP
+Legacy or "maxminddb" for MaxMind DB (GeoIP2).
+.TP
+\fBcountry_indexer_backend\fR BACKEND ;
+Specify what backend to use for the country indexer, either "geoip" for GeoIP
+Legacy or "maxminddb" for MaxMind DB (GeoIP2).
+.TP
+\fBmaxminddb_asn\fR " FILE " ;
+Specify the MaxMind DB file to use for ASN lookups.
+.TP
+\fBmaxminddb_country\fR " FILE " ;
+Specify the MaxMind DB file to use for country lookups.
+.TP
 \fBclient_v4_mask\fR NETMASK ;
 Set the IPv4 MASK for client_subnet INDEXERS.
 .TP
@@ -770,6 +784,11 @@ output_format XML;
 #geoip_v6_dat "/usr/share/GeoIP/GeoIPv6.dat";
 #geoip_asn_v4_dat "/usr/share/GeoIP/GeoIPASNum.dat" MEMORY_CACHE;
 #geoip_asn_v6_dat "/usr/share/GeoIP/GeoIPASNumv6.dat" MEMORY_CACHE;
+
+#asn_indexer_backend geoip;
+#country_indexer_backend geoip;
+#maxminddb_asn "/path/to/GeoLite2/ASN.mmdb";
+#maxminddb_country "/path/to/GeoList2/Country.mmdb";
 
 #client_v4_mask 255.255.255.0;
 #client_v6_mask ffff:ffff:ffff:ffff:ffff:ffff:0000:0000;

--- a/src/dsc.conf.sample.in
+++ b/src/dsc.conf.sample.in
@@ -191,6 +191,20 @@ dataset direction_vs_ipproto ip Direction:ip_direction IPProto:ip_proto any;
 #geoip_asn_v4_dat "/usr/share/GeoIP/GeoIPASNum.dat" MEMORY_CACHE;
 #geoip_asn_v6_dat "/usr/share/GeoIP/GeoIPASNumv6.dat" MEMORY_CACHE;
 
+# ASN/Country Indexer and MaxMind DB
+#
+#   Following configuration controls what backend the ASN and Country indexer
+#   will use and if/what MaxMind database (GeoIP2) files.
+#
+#   Available backends:
+#   - geoip
+#   - maxminddb
+#
+#asn_indexer_backend geoip;
+#country_indexer_backend geoip;
+#maxminddb_asn "/path/to/GeoLite2/ASN.mmdb";
+#maxminddb_country "/path/to/GeoList2/Country.mmdb";
+
 # Client Subnet Mask
 #
 #   Set the IPv4/IPv6 client subnet mask which is used for the

--- a/src/geoip.h
+++ b/src/geoip.h
@@ -32,35 +32,22 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __dsc_config_hooks_h
-#define __dsc_config_hooks_h
+#ifndef __dsc_geoip_h
+#define __dsc_geoip_h
 
-#include "dataset_opt.h"
-#include "geoip.h"
+#if defined(HAVE_LIBGEOIP) && defined(HAVE_GEOIP_H)
+#define HAVE_GEOIP 1
+#include <GeoIP.h>
+#endif
+#if defined(HAVE_LIBMAXMINDDB) && defined(HAVE_MAXMINDDB_H)
+#define HAVE_MAXMINDDB 1
+#include <maxminddb.h>
+#endif
 
-int open_interface(const char* interface);
-int set_bpf_program(const char* s);
-int add_local_address(const char* s, const char* m);
-int set_run_dir(const char* dir);
-int set_pid_file(const char* s);
-int set_statistics_interval(const char* s);
-int add_dataset(const char* name, const char* layer_ignored, const char* firstname, const char* firstindexer, const char* secondname, const char* secondindexer, const char* filtername, dataset_opt opts);
-int set_bpf_vlan_tag_byte_order(const char* which);
-int set_match_vlan(const char* s);
-int set_minfree_bytes(const char* s);
-int set_output_format(const char* output_format);
-void set_dump_reports_on_exit(void);
-int set_geoip_v4_dat(const char* dat, int options);
-int set_geoip_v6_dat(const char* dat, int options);
-int set_geoip_asn_v4_dat(const char* dat, int options);
-int set_geoip_asn_v6_dat(const char* dat, int options);
-int set_asn_indexer_backend(enum geoip_backend backend);
-int set_country_indexer_backend(enum geoip_backend backend);
-int set_maxminddb_asn(const char* file);
-int set_maxminddb_country(const char* file);
-int set_pcap_buffer_size(const char* s);
-void set_no_wait_interval(void);
-int set_pt_timeout(const char* s);
-void set_drop_ip_fragments(void);
+enum geoip_backend {
+    geoip_backend_none,
+    geoip_backend_libgeoip,
+    geoip_backend_libmaxminddb
+};
 
-#endif /* __dsc_config_hooks_h */
+#endif /* __dsc_geoip_h */


### PR DESCRIPTION
- Fix #178: Add support for MaxMind DB (GeoIP2)
  - New configuration options:
    - `maxminddb_asn`: Specify DB for ASN lookups
    - `maxminddb_country`: Specify DB for country lookups
- `asn_indexer`:
  - New configuration option `asn_indexer_backend` to control what ASN lookup backend to use
  - Remove some debug output and changed other to be in line with the country indexer
- `country_indexer`: New configuration option `asn_indexer_backend` to control what country lookup backend to use
- `daemon`: Moved some extern defines for functions to their headers