### PR TITLE
Response time statistics

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -72,6 +72,7 @@ AC_CHECK_LIB([nsl], [gethostbyname])
 AC_CHECK_LIB([socket], [connect])
 AC_CHECK_LIB([GeoIP], [GeoIP_open])
 PKG_CHECK_MODULES([libmaxminddb], [libmaxminddb], [AC_DEFINE([HAVE_LIBMAXMINDDB], [1], [Define to 1 if you have libmaxminddb.])], [:])
+AC_CHECK_LIB([m], [log10])
 
 # Checks for header files.
 AC_HEADER_STDC

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -23,7 +23,7 @@ dsc_SOURCES = asn_index.c certain_qnames_index.c client_index.c \
   parse_conf.c pcap.c qclass_index.c qname_index.c qnamelen_index.c \
   qr_aa_bits_index.c qtype_index.c query_classification_index.c rcode_index.c \
   rd_bit_index.c server_ip_addr_index.c tc_bit_index.c tld_index.c \
-  transport_index.c xmalloc.c \
+  transport_index.c xmalloc.c response_time_index.c \
   ext/base64.c ext/lookup3.c \
   pcap_layers/pcap_layers.c \
   pcap-thread/pcap_thread.c
@@ -36,7 +36,7 @@ dist_dsc_SOURCES = asn_index.h base64.h certain_qnames_index.h client_index.h \
   parse_conf.h pcap.h qclass_index.h qname_index.h qnamelen_index.h \
   qr_aa_bits_index.h qtype_index.h query_classification_index.h rcode_index.h \
   rd_bit_index.h server_ip_addr_index.h syslog_debug.h tc_bit_index.h \
-  tld_index.h transport_index.h xmalloc.h \
+  tld_index.h transport_index.h xmalloc.h response_time_index.h \
   pcap_layers/byteorder.h pcap_layers/pcap_layers.h \
   pcap-thread/pcap_thread.h
 dsc_LDADD = $(PTHREAD_LIBS) $(libmaxminddb_LIBS)

--- a/src/asn_index.c
+++ b/src/asn_index.c
@@ -333,7 +333,7 @@ asn_cmpfunc(const void* a, const void* b)
     return strcasecmp(a, b);
 }
 
-void asn_indexer_init()
+void asn_init(void)
 {
     switch (asn_indexer_backend) {
     case geoip_backend_libgeoip:

--- a/src/asn_index.h
+++ b/src/asn_index.h
@@ -42,6 +42,6 @@
 int asn_indexer(const dns_message*);
 int asn_iterator(const char** label);
 void asn_reset(void);
-void asn_indexer_init();
+void asn_init(void);
 
 #endif /* __dsc_asn_index_h */

--- a/src/client_subnet_index.c
+++ b/src/client_subnet_index.c
@@ -111,9 +111,8 @@ void client_subnet_reset()
     next_idx = 0;
 }
 
-void client_subnet_indexer_init(void)
+void client_subnet_init(void)
 {
-    /* XXXDPW */
     inXaddr_pton("255.255.255.0", &v4mask);
     inXaddr_pton("ffff:ffff:ffff:ffff:ffff:ffff:0000:0000", &v6mask);
 }

--- a/src/client_subnet_index.h
+++ b/src/client_subnet_index.h
@@ -42,7 +42,7 @@
 int client_subnet_indexer(const dns_message*);
 int client_subnet_iterator(const char** label);
 void client_subnet_reset(void);
-void client_subnet_indexer_init(void);
+void client_subnet_init(void);
 int client_subnet_v4_mask_set(const char* mask);
 int client_subnet_v6_mask_set(const char* mask);
 

--- a/src/compat.h
+++ b/src/compat.h
@@ -39,6 +39,12 @@
 
 #include <stddef.h>
 
+#ifdef __OpenBSD__
+#define PRItime "%lld.%ld"
+#else
+#define PRItime "%ld.%ld"
+#endif
+
 const char* dsc_strerror(int errnum, char* buf, size_t buflen);
 
 #endif /* __dsc_compat_h */

--- a/src/config_hooks.c
+++ b/src/config_hooks.c
@@ -165,11 +165,21 @@ int set_statistics_interval(const char* s)
     return 1;
 }
 
+static int response_time_indexer_used = 0;
+
 int add_dataset(const char* name, const char* layer_ignored,
     const char* firstname, const char* firstindexer,
     const char* secondname, const char* secondindexer, const char* filtername, dataset_opt opts)
 {
     char* dup;
+
+    if (!strcmp(firstindexer, "response_time") || !strcmp(secondindexer, "response_time")) {
+        if (response_time_indexer_used) {
+            dsyslogf(LOG_ERR, "unable to create dataset %s: response_time indexer already used, can only be used in one dataset", name);
+            return 0;
+        }
+        response_time_indexer_used = 1;
+    }
 
     if (!dataset_hash) {
         if (!(dataset_hash = hash_create(MAX_HASH_SIZE, dataset_hashfunc, dataset_cmpfunc, 0, xfree, xfree))) {

--- a/src/country_index.c
+++ b/src/country_index.c
@@ -257,7 +257,7 @@ country_cmpfunc(const void* a, const void* b)
     return strcasecmp(a, b);
 }
 
-void country_indexer_init()
+void country_init(void)
 {
     switch (country_indexer_backend) {
     case geoip_backend_libgeoip:

--- a/src/dns_message.h
+++ b/src/dns_message.h
@@ -70,6 +70,7 @@ struct transport_message {
 
 struct dns_message {
     transport_message* tm;
+    unsigned short     id;
     unsigned short     qtype;
     unsigned short     qclass;
     unsigned short     msglen;
@@ -94,11 +95,13 @@ struct dns_message {
 
 void dns_message_handle(dns_message* m);
 int dns_message_add_array(const char* name, const char* fn, const char* fi, const char* sn, const char* si, const char* f, dataset_opt opts);
+void dns_message_flush_arrays(void);
 void dns_message_report(FILE* fp, md_array_printer* printer);
 void        dns_message_clear_arrays(void);
 const char* dns_message_QnameToNld(const char* qname, int nld);
 const char* dns_message_tld(dns_message* m);
-void dns_message_init(void);
+void dns_message_filters_init(void);
+void dns_message_indexers_init(void);
 int add_qname_filter(const char* name, const char* pat);
 
 #include <arpa/nameser.h>

--- a/src/dns_protocol.c
+++ b/src/dns_protocol.c
@@ -188,6 +188,7 @@ int dns_protocol_handler(const u_char* buf, int len, void* udata)
         m.malformed = 1;
         return 0;
     }
+    m.id     = nptohs(buf);
     us       = nptohs(buf + 2);
     m.qr     = (us >> 15) & 0x01;
     m.opcode = (us >> 11) & 0x0F;

--- a/src/dsc.1.in
+++ b/src/dsc.1.in
@@ -73,6 +73,9 @@ Enable immediate mode on interfaces.
 .B \-T
 Disable the usage of threads.
 .TP
+.B \-D
+Don't exit after first write when in debug mode.
+.TP
 .B \-v
 Print version and exit.
 .SH FILES

--- a/src/dsc.conf.5.in
+++ b/src/dsc.conf.5.in
@@ -211,6 +211,57 @@ Set the IPv4 MASK for client_subnet INDEXERS.
 .TP
 \fBclient_v6_mask\fR NETMASK ;
 Set the IPv6 MASK for client_subnet INDEXERS.
+.TP
+\fBresponse_time_mode\fR MODE ;
+Set the output MODE of the response time indexer:
+.RS
+.TP
+\fBbucket\fR
+Count response time in buckets of microseconds, see \fBresponse_time_bucket_size\fR
+for setting the size of the buckets.
+.TP
+\fBlog10\fR
+Count response time in logarithmic scale with base 10.
+.TP
+\fBlog2\fR
+Count response time in logarithmic scale with base 2.
+.RE
+.TP
+\fBresponse_time_max_queries\fR NUMBER ;
+Set the maximum number of queries to keep track of.
+.TP
+\fBresponse_time_full_mode\fR MODE ;
+If the number of queries tracked exceeds \fBresponse_time_max_queries\fR the
+MODE will control how to handle it:
+.RS
+.TP
+\fBdrop_query\fR
+Drop the incoming query.
+.TP
+\fBdrop_oldest\fR
+Drop the oldest query being tracked and accept the incoming one.
+.RE
+.TP
+\fBresponse_time_max_seconds\fR SECONDS ;
+Set the maximum seconds to keep a query but a query can still be matched to
+a response while being outside this limit, see \fBresponse_time_max_sec_mode\fR
+on how to handle those situations.
+.TP
+\fBresponse_time_max_sec_mode\fR MODE ;
+Control how to handle queries and responses which are match successfully but
+exceeds \fBresponse_time_max_seconds\fR:
+.RS
+.TP
+\fBceil\fR
+The query will be counted as successful but the time it took will be the
+maximum seconds (think ceiling, or ceil()).
+.TP
+\fBtimed_out\fR
+The query will be counted as timed out.
+.RE
+.TP
+\fBresponse_time_bucket_size\fR SIZE ;
+Control the size of bucket (microseconds) in bucket mode.
 .SH DATASETS
 A \fBdataset\fR is a 2-D array of counters.  For example, you
 might have a dataset with \*(lqQuery Type\*(rq along one dimension and
@@ -474,6 +525,19 @@ messages received with each combination of QR,AA bits.  Normally
 the authoritative name server should *receive* only *queries*.  If
 the name server is the target of a DNS reflection attack, it will
 probably receive DNS *responses* which have the QR bit set.
+.TP
+\fBresponse_time\fR
+An indexer to track queries and return the response time in buckets along with
+other state buckets for timeouts, missing queries (received a response but
+have never seen the query), dropped queries (due to memory limitations) and
+internal errors.
+Queries are matched against responses by checking (in this order) the DNS ID,
+the IP version and protocol, client IP, client port, server IP and last server
+port.
+There are a few configuration options to control how response time statistics
+are gathered and handled, please see CONFIGURATION.
+NOTE: Only one instance of this indexer can be used in a dataset, this is due
+to the state to stores and the design of DSC.
 .SH "DNS FILTERS"
 You must specify one or more of the following filters (separated
 by commas) on the \fBdataset\fR line. Note that multiple filters
@@ -769,6 +833,7 @@ dataset client_port_range dns All:null PortRange:dns_sport_range queries-only;
 #dataset third_ld_vs_rcode dns Rcode:rcode ThirdLD:third_ld replies-only max-cells=50;
 dataset direction_vs_ipproto ip Direction:ip_direction IPProto:ip_proto any;
 #dataset dns_ip_version_vs_qtype dns IPVersion:dns_ip_version Qtype:qtype queries-only;
+#dataset response_time dns All:null ResponseTime:response_time;
 #dataset priming_queries dns Transport:transport EDNSBufSiz:edns_bufsiz priming-query,queries-only;
 #dataset priming_responses dns All:null ReplyLen:msglen priming-query,replies-only;
 #dataset qr_aa_bits dns Direction:ip_direction QRAABits:qr_aa_bits any;
@@ -792,6 +857,13 @@ output_format XML;
 
 #client_v4_mask 255.255.255.0;
 #client_v6_mask ffff:ffff:ffff:ffff:ffff:ffff:0000:0000;
+
+#response_time_mode log10;
+#response_time_max_queries 1000000;
+#response_time_full_mode drop_query;
+#response_time_max_seconds 5;
+#response_time_max_sec_mode ceil;
+#response_time_bucket_size 100;
 .fi
 .SH FILES
 @etcdir@/dsc.conf

--- a/src/dsc.conf.sample.in
+++ b/src/dsc.conf.sample.in
@@ -118,6 +118,7 @@ dataset client_port_range dns All:null PortRange:dns_sport_range queries-only;
 #dataset third_ld_vs_rcode dns Rcode:rcode ThirdLD:third_ld replies-only max-cells=50;
 dataset direction_vs_ipproto ip Direction:ip_direction IPProto:ip_proto any;
 #dataset dns_ip_version_vs_qtype dns IPVersion:dns_ip_version Qtype:qtype queries-only;
+#dataset response_time dns All:null ResponseTime:response_time;
 
 #  datasets for collecting data on priming queries at root nameservers
 #dataset priming_queries dns Transport:transport EDNSBufSiz:edns_bufsiz priming-query,queries-only;
@@ -212,3 +213,39 @@ dataset direction_vs_ipproto ip Direction:ip_direction IPProto:ip_proto any;
 #
 #client_v4_mask 255.255.255.0;
 #client_v6_mask ffff:ffff:ffff:ffff:ffff:ffff:0000:0000;
+
+# Response Time indexer
+#
+#  These settings are for the response time indexer, it tracks query
+#  to match it with a response and gives statistics about the time it
+#  took to answer the query.
+#
+#  Available statistical output modes:
+#  - bucket
+#  - log10 (default)
+#  - log2
+#
+#response_time_mode log10;
+#response_time_max_queries 1000000;
+#
+#  If the number of queries tracked exceeds max_queries the full_mode
+#  will control how to handle it:
+#  - drop_query: Drop the incoming query.
+#  - drop_oldest: Drop the oldest query being tracked and accept the
+#                 incoming one.
+#
+#response_time_full_mode drop_query;
+#
+#  Set the maximum seconds to keep a query but a query can still be
+#  matched to a response while being outside this limit and therefor
+#  there is a mode on how to handle that situation:
+#  - ceil: The query will be counted as successful but the time it took
+#          will be the maximum seconds (think ceiling, or ceil()).
+#  - timed_out: The query will be counted as timed out.
+#
+#response_time_max_seconds 5;
+#response_time_max_sec_mode ceil;
+#
+#  Control the size of bucket (microseconds) in bucket mode.
+#
+#response_time_bucket_size 100;

--- a/src/md_array.c
+++ b/src/md_array.c
@@ -218,6 +218,32 @@ int md_array_count(md_array* a, const void* vp)
     return ++a->array[i1].array[i2];
 }
 
+void md_array_flush(md_array* a)
+{
+    const void* vp;
+
+    if (a->d1.indexer->flush_fn)
+        a->d1.indexer->flush_fn(flush_on);
+    if (a->d2.indexer->flush_fn)
+        a->d2.indexer->flush_fn(flush_on);
+
+    if (a->d1.indexer->flush_fn) {
+        while ((vp = a->d1.indexer->flush_fn(flush_get))) {
+            md_array_count(a, vp);
+        }
+    }
+    if (a->d2.indexer->flush_fn) {
+        while ((vp = a->d2.indexer->flush_fn(flush_get))) {
+            md_array_count(a, vp);
+        }
+    }
+
+    if (a->d1.indexer->flush_fn)
+        a->d1.indexer->flush_fn(flush_off);
+    if (a->d2.indexer->flush_fn)
+        a->d2.indexer->flush_fn(flush_off);
+}
+
 int md_array_print(md_array* a, md_array_printer* pr, FILE* fp)
 {
     const char* label1;

--- a/src/md_array.h
+++ b/src/md_array.h
@@ -52,11 +52,19 @@ typedef struct md_array_list    md_array_list;
 
 typedef int (*filter_func)(const dns_message* m, const void* context);
 
+enum flush_mode {
+    flush_on,
+    flush_get,
+    flush_off
+};
+
 struct indexer {
     const char* name;
+    void (*init_fn)(void);
     int (*index_fn)(const dns_message*);
     int (*iter_fn)(const char**);
     void (*reset_fn)(void);
+    const dns_message* (*flush_fn)(enum flush_mode);
 };
 
 struct filter_defn {
@@ -115,9 +123,10 @@ struct md_array_list {
     md_array_list* next;
 };
 
-void      md_array_clear(md_array*);
-int       md_array_count(md_array*, const void*);
 md_array* md_array_create(const char* name, filter_list*, const char*, indexer*, const char*, indexer*);
+void md_array_clear(md_array*);
+int  md_array_count(md_array*, const void*);
+void md_array_flush(md_array* a);
 int md_array_print(md_array* a, md_array_printer* pr, FILE* fp);
 filter_list** md_array_filter_list_append(filter_list** fl, filter_defn* f);
 filter_defn* md_array_create_filter(const char* name, filter_func, const void* context);

--- a/src/pcap.c
+++ b/src/pcap.c
@@ -114,7 +114,7 @@ int   vlan_tag_needs_byte_conversion = 1;
 #if 0
 static int debug_count = 20;
 #endif
-static struct timeval last_ts;
+struct timeval        last_ts;
 static struct timeval start_ts;
 static struct timeval finish_ts;
 #define MAX_VLAN_IDS 100
@@ -1075,9 +1075,9 @@ int pcap_ifname_iterator(const char**);
 int pcap_stat_iterator(const char**);
 
 static indexer indexers[] = {
-    { "ifname", NULL, pcap_ifname_iterator, NULL },
-    { "pcap_stat", NULL, pcap_stat_iterator, NULL },
-    { NULL, NULL, NULL, NULL },
+    { "ifname", 0, 0, pcap_ifname_iterator },
+    { "pcap_stat", 0, 0, pcap_stat_iterator },
+    { 0 },
 };
 
 int pcap_ifname_iterator(const char** label)

--- a/src/pcap.h
+++ b/src/pcap.h
@@ -41,6 +41,8 @@
 
 #include <stdio.h>
 
+extern struct timeval last_ts;
+
 void Pcap_init(const char* device, int promisc, int monitor, int immediate, int threads, int buffer_size);
 int  Pcap_run();
 void Pcap_stop(void);

--- a/src/response_time_index.c
+++ b/src/response_time_index.c
@@ -1,0 +1,434 @@
+/*
+ * Copyright (c) 2008-2018, OARC, Inc.
+ * Copyright (c) 2007-2008, Internet Systems Consortium, Inc.
+ * Copyright (c) 2003-2007, The Measurement Factory, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "response_time_index.h"
+#include "hashtbl.h"
+#include "inX_addr.h"
+#include "xmalloc.h"
+#include "syslog_debug.h"
+#include "pcap.h"
+#include "compat.h"
+
+#include <math.h>
+#include <assert.h>
+
+#define TIMED_OUT 0
+#define MISSING_QUERY 1
+#define DROPPED_QUERY 2
+#define INTERNAL_ERROR 3
+#define FIRST_BUCKET 4
+
+struct query;
+struct query {
+    struct query *    prev, *next;
+    transport_message tm;
+    dns_message       m;
+};
+
+#define MAX_ARRAY_SZ 65536
+static hashtbl*                        theHash      = 0;
+static enum response_time_mode         mode         = response_time_log10;
+static time_t                          max_sec      = 5;
+static enum response_time_max_sec_mode max_sec_mode = response_time_ceil;
+static unsigned int                    bucket_size  = 100;
+static size_t                          max_queries = 1000000, num_queries = 0;
+static struct query *                  qfirst = 0, *qlast = 0;
+static int                             max_iter = INTERNAL_ERROR, next_iter, flushing = 0;
+static enum response_time_full_mode    full_mode = response_time_drop_query;
+
+static unsigned int _hash(const struct query* q)
+{
+    if (q->m.qr)
+        return inXaddr_hash(&q->tm.dst_ip_addr) ^ ((q->tm.dst_port & 0xffff) | (q->m.id << 16));
+    return inXaddr_hash(&q->tm.src_ip_addr) ^ ((q->tm.src_port & 0xffff) | (q->m.id << 16));
+}
+
+static int _cmp(const struct query* a, const struct query* b)
+{
+    int cmp;
+
+    // compare DNS ID
+    if (a->m.id != b->m.id)
+        return a->m.id < b->m.id ? -1 : 1;
+
+    // compare IP version, since inXaddr_cmp() does not, and protocol
+    if (a->tm.ip_version != b->tm.ip_version)
+        return a->tm.ip_version < b->tm.ip_version ? -1 : 1;
+    if (a->tm.proto != b->tm.proto)
+        return a->tm.proto < b->tm.proto ? -1 : 1;
+
+    // compare client IP&port first since other should be server and more static data
+    if (!a->m.qr && !b->m.qr) {
+        // both are queries, compare source address first as that is the client
+        if ((cmp = inXaddr_cmp(&a->tm.src_ip_addr, &b->tm.src_ip_addr)))
+            return cmp;
+        if (a->tm.src_port != b->tm.src_port)
+            return a->tm.src_port < b->tm.src_port ? -1 : 1;
+        if ((cmp = inXaddr_cmp(&a->tm.dst_ip_addr, &b->tm.dst_ip_addr)))
+            return cmp;
+        if (a->tm.dst_port != b->tm.dst_port)
+            return a->tm.dst_port < b->tm.dst_port ? -1 : 1;
+    } else if (a->m.qr && b->m.qr) {
+        // both are responses, compare destination address first as that is the client
+        if ((cmp = inXaddr_cmp(&a->tm.dst_ip_addr, &b->tm.dst_ip_addr)))
+            return cmp;
+        if (a->tm.dst_port != b->tm.dst_port)
+            return a->tm.dst_port < b->tm.dst_port ? -1 : 1;
+        if ((cmp = inXaddr_cmp(&a->tm.src_ip_addr, &b->tm.src_ip_addr)))
+            return cmp;
+        if (a->tm.src_port != b->tm.src_port)
+            return a->tm.src_port < b->tm.src_port ? -1 : 1;
+    } else if (a->m.qr && !b->m.qr) {
+        // a is a response and b is a query, compare a's destination with b's source first
+        if ((cmp = inXaddr_cmp(&a->tm.dst_ip_addr, &b->tm.src_ip_addr)))
+            return cmp;
+        if (a->tm.dst_port != b->tm.src_port)
+            return a->tm.dst_port < b->tm.src_port ? -1 : 1;
+        if ((cmp = inXaddr_cmp(&a->tm.src_ip_addr, &b->tm.dst_ip_addr)))
+            return cmp;
+        if (a->tm.src_port != b->tm.dst_port)
+            return a->tm.src_port < b->tm.dst_port ? -1 : 1;
+    } else {
+        // a is a query and b is a response, compare a's source with b's destination first
+        if ((cmp = inXaddr_cmp(&a->tm.src_ip_addr, &b->tm.dst_ip_addr)))
+            return cmp;
+        if (a->tm.src_port != b->tm.dst_port)
+            return a->tm.src_port < b->tm.dst_port ? -1 : 1;
+        if ((cmp = inXaddr_cmp(&a->tm.dst_ip_addr, &b->tm.src_ip_addr)))
+            return cmp;
+        if (a->tm.dst_port != b->tm.src_port)
+            return a->tm.dst_port < b->tm.src_port ? -1 : 1;
+    }
+
+    return 0;
+}
+
+int response_time_indexer(const dns_message* m)
+{
+    struct query       q, *obj;
+    transport_message* tm  = m->tm;
+    int                ret = -1;
+
+    if (flushing) {
+        dfprintf(1, "response_time: flushing %u %s", m->id, m->qname);
+        return TIMED_OUT;
+    }
+
+    if (m->malformed) {
+        return -1;
+    }
+
+    dfprintf(1, "response_time: %s %u %s", m->qr ? "response" : "query", m->id, m->qname);
+
+    if (!theHash) {
+        theHash = hash_create(MAX_ARRAY_SZ, (hashfunc*)_hash, (hashkeycmp*)_cmp, 0, 0, 0);
+        if (!theHash)
+            return INTERNAL_ERROR;
+    }
+
+    q.m     = *m;
+    q.tm    = *tm;
+    q.m.tm  = &q.tm;
+    q.m.tld = 0;
+
+    obj = hash_find(&q, theHash);
+
+    if (m->qr) {
+        struct timeval diff;
+        unsigned long  us;
+        int            iter;
+
+        if (!obj) {
+            // got a response without a query,
+            dfprint(1, "response_time: missing query for response");
+            return MISSING_QUERY;
+        }
+
+        // TODO: compare more?
+        // - qclass/qtype, qname
+
+        // found query, remove and calculate index
+        if (obj->prev)
+            obj->prev->next = obj->next;
+        if (obj->next)
+            obj->next->prev = obj->prev;
+        if (obj == qfirst)
+            qfirst = obj->next;
+        if (obj == qlast)
+            qlast = obj->prev;
+        hash_remove(obj, theHash);
+        num_queries--;
+
+        q      = *obj;
+        q.m.tm = &q.tm;
+        xfree(obj);
+
+        diff.tv_sec  = tm->ts.tv_sec - q.tm.ts.tv_sec;
+        diff.tv_usec = tm->ts.tv_usec - q.tm.ts.tv_usec;
+        if (diff.tv_usec >= 1000000) {
+            diff.tv_sec += 1;
+            diff.tv_usec -= 1000000;
+        } else if (diff.tv_usec < 0) {
+            diff.tv_sec -= 1;
+            diff.tv_usec += 1000000;
+        }
+
+        if (diff.tv_sec < 0 || diff.tv_usec < 0) {
+            dfprintf(1, "response_time: bad diff " PRItime ", " PRItime " - " PRItime, diff.tv_sec, diff.tv_usec, q.tm.ts.tv_sec, q.tm.ts.tv_usec, tm->ts.tv_sec, tm->ts.tv_usec);
+            return INTERNAL_ERROR;
+        }
+        if (diff.tv_sec >= max_sec) {
+            switch (max_sec_mode) {
+            case response_time_ceil:
+                dfprintf(2, "response_time: diff " PRItime " ceiled to " PRItime, diff.tv_sec, diff.tv_usec, max_sec, 0L);
+                diff.tv_sec  = max_sec;
+                diff.tv_usec = 0;
+                break;
+            case response_time_timed_out:
+                dfprintf(1, "response_time: diff " PRItime " too old, timed out", diff.tv_sec, diff.tv_usec);
+                return TIMED_OUT;
+            default:
+                dfprint(1, "response_time: bad max_sec_mode");
+                return INTERNAL_ERROR;
+            }
+        }
+
+        us = (diff.tv_sec * 1000000) + diff.tv_usec;
+        switch (mode) {
+        case response_time_bucket:
+            iter = FIRST_BUCKET + (us / bucket_size);
+            dfprintf(2, "response_time: found q/r us:%lu, put in bucket %d (%lu-%lu usec)", us, iter, (us / bucket_size) * bucket_size, ((us / bucket_size) + 1) * bucket_size);
+            break;
+        case response_time_log10: {
+            double d = log10(us);
+            if (d < 0) {
+                dfprintf(1, "response_time: bad log10(%lu) ret %f", us, d);
+                return INTERNAL_ERROR;
+            }
+            iter = FIRST_BUCKET + (int)d;
+            dfprintf(2, "response_time: found q/r us:%lu, log10 %d (%.0f-%.0f usec)", us, iter, pow(10, (int)d), pow(10, (int)d + 1));
+            break;
+        }
+        case response_time_log2: {
+            double d = log2(us);
+            if (d < 0) {
+                dfprintf(1, "response_time: bad log2(%lu) ret %f", us, d);
+                return INTERNAL_ERROR;
+            }
+            iter = FIRST_BUCKET + (int)d;
+            dfprintf(2, "response_time: found q/r us:%lu, log2 %d (%.0f-%.0f usec)", us, iter, pow(2, (int)d), pow(2, (int)d + 1));
+            break;
+        }
+        default:
+            dfprint(1, "response_time: bad mode");
+            return INTERNAL_ERROR;
+        }
+
+        if (iter > max_iter)
+            max_iter = iter;
+        return iter;
+    }
+
+    if (obj) {
+        // Found another query in the hash so the old one have timed out,
+        // reuse the obj for the new query
+        obj->tm.ts = tm->ts;
+        if (obj != qlast) {
+            if (obj->prev)
+                obj->prev->next = obj->next;
+            if (obj->next) {
+                if (obj == qfirst)
+                    qfirst      = obj->next;
+                obj->next->prev = obj->prev;
+            }
+            obj->prev = qlast;
+            obj->next = 0;
+            assert(qlast);
+            qlast->next = obj;
+            qlast       = obj;
+        }
+        dfprintf(1, "response_time: reuse %p, timed out", obj);
+        return TIMED_OUT;
+    }
+
+    if (num_queries >= max_queries) {
+        // We're at max, see if we can time out the oldest query
+        ret = TIMED_OUT;
+        assert(qfirst);
+        if (tm->ts.tv_sec - qfirst->tm.ts.tv_sec < max_sec) {
+            // no, so what to do?
+            switch (full_mode) {
+            case response_time_drop_query:
+                dfprint(1, "response_time: full and oldest not old enough");
+                return DROPPED_QUERY;
+            case response_time_drop_oldest:
+                ret = DROPPED_QUERY;
+                dfprint(2, "response_time: full and dropping oldest");
+                break;
+            default:
+                dfprint(1, "response_time: bad full_mode");
+                return INTERNAL_ERROR;
+            }
+        }
+
+        // remove oldest obj from hash and reuse it
+        obj    = qfirst;
+        qfirst = obj->next;
+        if (qfirst)
+            qfirst->prev = 0;
+        hash_remove(obj, theHash);
+        num_queries--;
+        dfprintf(1, "response_time: reuse %p, too old", obj);
+    } else {
+        obj = xcalloc(1, sizeof(*obj));
+        if (!obj) {
+            dfprint(1, "response_time: failed to alloc obj");
+            return INTERNAL_ERROR;
+        }
+    }
+
+    *obj      = q;
+    obj->m.tm = &obj->tm;
+    if (hash_add(obj, obj, theHash)) {
+        xfree(obj);
+        dfprint(1, "response_time: failed to add to hash");
+        return INTERNAL_ERROR;
+    }
+
+    obj->prev = qlast;
+    obj->next = 0;
+    if (qlast)
+        qlast->next = obj;
+    qlast           = obj;
+    if (!qfirst)
+        qfirst = obj;
+    num_queries++;
+    dfprintf(2, "response_time: add %p, %lu/%lu queries", obj, num_queries, max_queries);
+
+    return ret;
+}
+
+int response_time_iterator(const char** label)
+{
+    char label_buf[128];
+
+    if (!label) {
+        next_iter = 0;
+        return max_iter + 1;
+    }
+    if (next_iter > max_iter) {
+        return -1;
+    }
+
+    if (next_iter < FIRST_BUCKET) {
+        switch (next_iter) {
+        case TIMED_OUT:
+            *label = "timeouts";
+            break;
+        case MISSING_QUERY:
+            *label = "missing_queries";
+            break;
+        case DROPPED_QUERY:
+            *label = "dropped_queries";
+            break;
+        case INTERNAL_ERROR:
+            *label = "internal_errors";
+            break;
+        default:
+            return -1;
+        }
+    } else {
+        switch (mode) {
+        case response_time_bucket:
+            snprintf(label_buf, 128, "%d-%d", (next_iter - FIRST_BUCKET) * bucket_size, (next_iter - FIRST_BUCKET + 1) * bucket_size);
+            break;
+        case response_time_log10:
+            snprintf(label_buf, 128, "%.0f-%.0f", pow(10, next_iter - FIRST_BUCKET), pow(10, next_iter - FIRST_BUCKET + 1));
+            break;
+        case response_time_log2:
+            snprintf(label_buf, 128, "%.0f-%.0f", pow(2, next_iter - FIRST_BUCKET), pow(2, next_iter - FIRST_BUCKET + 1));
+            break;
+        default:
+            return -1;
+        }
+        *label = label_buf;
+    }
+
+    return next_iter++;
+}
+
+void response_time_reset()
+{
+    max_iter = INTERNAL_ERROR;
+}
+
+static struct query* flushed_obj = 0;
+
+const dns_message* response_time_flush(enum flush_mode mode)
+{
+    switch (mode) {
+    case flush_get:
+        if (qfirst && last_ts.tv_sec - qfirst->tm.ts.tv_sec >= max_sec) {
+            if (flushed_obj)
+                xfree(flushed_obj);
+
+            flushed_obj = qfirst;
+            qfirst      = flushed_obj->next;
+            if (qfirst)
+                qfirst->prev = 0;
+            hash_remove(flushed_obj, theHash);
+            num_queries--;
+            return &flushed_obj->m;
+        }
+        break;
+    case flush_on:
+        flushing = 1;
+        break;
+    case flush_off:
+        if (flushed_obj) {
+            xfree(flushed_obj);
+            flushed_obj = 0;
+        }
+        flushing = 0;
+        break;
+    default:
+        break;
+    }
+
+    return 0;
+}

--- a/src/response_time_index.h
+++ b/src/response_time_index.h
@@ -34,14 +34,30 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __dsc_country_index_h
-#define __dsc_country_index_h
+#ifndef __dsc_response_time_index_h
+#define __dsc_response_time_index_h
 
 #include "dns_message.h"
 
-int country_indexer(const dns_message*);
-int country_iterator(const char** label);
-void country_reset(void);
-void country_init(void);
+enum response_time_mode {
+    response_time_bucket,
+    response_time_log10,
+    response_time_log2
+};
 
-#endif /* __dsc_country_index_h */
+enum response_time_max_sec_mode {
+    response_time_ceil,
+    response_time_timed_out
+};
+
+enum response_time_full_mode {
+    response_time_drop_oldest,
+    response_time_drop_query
+};
+
+int response_time_indexer(const dns_message*);
+int response_time_iterator(const char** label);
+void               response_time_reset(void);
+const dns_message* response_time_flush(enum flush_mode mode);
+
+#endif /* __dsc_response_time_index_h */


### PR DESCRIPTION
- Rename initialization functions for ASN, client subnet and country indexer
- Split `dns_message_init()` into two functions `dns_message_filters_init()` and `dns_message_indexers_init()`, filters need to be initialized before conf is read and indexers after
- Add flush function to `indexer` and call it before forking and report output
- Add option `-D` to not exit after first write in debug mode
- Add DNS ID to `struct dns_message` and save it while parsing the DNS message
- Make last timestamp seen (`last_ts`) global
- Fix #162: New indexer `response_time`, track queries and report response time statistics