### PR TITLE
FreeBSD 11 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ make
 make install
 ```
 
+NOTE: If building fails on FreeBSD/OpenBSD, try adding these configure
+options: `--with-extra-cflags="-I /usr/local/include" --with-extra-ldflags="-L/usr/local/lib"`.
+
 ## Building from Git repository
 
 If you are building `dsc` from it's Git repository you will first need
@@ -80,6 +83,9 @@ git submodule update --init
 make
 make install
 ```
+
+NOTE: If building fails on FreeBSD/OpenBSD, try adding these configure
+options: `--with-extra-cflags="-I /usr/local/include" --with-extra-ldflags="-L/usr/local/lib"`.
 
 ## Puppet
 

--- a/src/asn_index.c
+++ b/src/asn_index.c
@@ -45,6 +45,7 @@
 #include "compat.h"
 #endif
 
+#include <stdlib.h>
 #include <string.h>
 #ifdef HAVE_MAXMINDDB
 #include <inttypes.h>

--- a/src/config_hooks.c
+++ b/src/config_hooks.c
@@ -47,6 +47,8 @@
 #include <unistd.h>
 #include <errno.h>
 #include <limits.h>
+#include <stdlib.h>
+#include <string.h>
 
 extern int promisc_flag;
 extern int monitor_flag;

--- a/src/country_index.c
+++ b/src/country_index.c
@@ -48,6 +48,8 @@
 #ifdef HAVE_MAXMINDDB
 #include <errno.h>
 #endif
+#include <string.h>
+#include <strings.h>
 
 extern int                debug_flag;
 extern char*              geoip_v4_dat;

--- a/src/parse_conf.c
+++ b/src/parse_conf.c
@@ -45,6 +45,8 @@
 #include "client_subnet_index.h"
 
 #include <errno.h>
+#include <string.h>
+#include <stdlib.h>
 
 #define PARSE_CONF_EINVAL -2
 #define PARSE_CONF_ERROR -1


### PR DESCRIPTION
- Add documentation about extra configure options that might be needed for FreeBSD/OpenBSD
- Fix compile warnings on FreeBSD 11.2