### PR TITLE
sigint, DNSTAP UNIX socket, DNSTAP init

### DIFF
--- a/src/daemon.c
+++ b/src/daemon.c
@@ -512,7 +512,7 @@ int main(int argc, char* argv[])
             dsyslogf(LOG_ERR, "Unable to install signal handler for SIGTERM: %s", dsc_strerror(errno, errbuf, sizeof(errbuf)));
         if (sigaction(SIGQUIT, &action, NULL))
             dsyslogf(LOG_ERR, "Unable to install signal handler for SIGQUIT: %s", dsc_strerror(errno, errbuf, sizeof(errbuf)));
-        if (!nodaemon_flag && sigaction(SIGINT, &action, NULL))
+        if (nodaemon_flag && sigaction(SIGINT, &action, NULL))
             dsyslogf(LOG_ERR, "Unable to install signal handler for SIGINT: %s", dsc_strerror(errno, errbuf, sizeof(errbuf)));
     }
 


### PR DESCRIPTION
- `daemon`: Fix bug with listening for SIGINT when in foreground mode
- `dnstap`:
  - Fix #217: Unlink UNIX socket on exit if successfully initiated
  - Fix startup bug, `exit()` if unable to initialize