### PR TITLE
GeoIP, asn indexer

### DIFF
--- a/rpm/dsc.spec
+++ b/rpm/dsc.spec
@@ -11,8 +11,8 @@ URL:            https://www.dns-oarc.net/oarc/data/dsc
 Source0:        https://www.dns-oarc.net/files/dsc/%{name}-%{version}.tar.gz?/%{name}_%{version}.orig.tar.gz
 
 BuildRequires:  libpcap-devel
-%if 0%{?sle_version}
-BuildRequires:  GeoIP-devel
+%if 0%{?suse_version} || 0%{?sle_version}
+BuildRequires:  libmaxminddb-devel
 %else
 BuildRequires:  GeoIP-devel
 BuildRequires:  libmaxminddb-devel

--- a/src/asn_index.c
+++ b/src/asn_index.c
@@ -40,7 +40,17 @@
 #include "xmalloc.h"
 #include "hashtbl.h"
 #include "syslog_debug.h"
+
 #include "geoip.h"
+#if defined(HAVE_LIBGEOIP) && defined(HAVE_GEOIP_H)
+#define HAVE_GEOIP 1
+#include <GeoIP.h>
+#endif
+#if defined(HAVE_LIBMAXMINDDB) && defined(HAVE_MAXMINDDB_H)
+#define HAVE_MAXMINDDB 1
+#include <maxminddb.h>
+#endif
+
 #ifdef HAVE_MAXMINDDB
 #include "compat.h"
 #endif
@@ -73,8 +83,10 @@ static GeoIP* geoip6 = NULL;
 static MMDB_s mmdb;
 static char   _mmasn[32];
 #endif
-static char  ipstr[81];
-static char* nodb       = "NODB";
+static char ipstr[81];
+#ifdef HAVE_GEOIP
+static char* nodb = "NODB";
+#endif
 static char* unknown    = "??";
 static char* unknown_v4 = "?4";
 static char* unknown_v6 = "?6";
@@ -232,11 +244,11 @@ asn_get_from_message(dns_message* m)
                         break;
                     default:
                         dfprintf(1, "asn_index: found entry in MMDB but unknown type %u", entry_data.type);
-                        asn = unknown_v4;
+                        asn = unknown_v6;
                     }
                 }
             } else {
-                asn = unknown_v4;
+                asn = unknown_v6;
             }
 #endif
             break;

--- a/src/config_hooks.c
+++ b/src/config_hooks.c
@@ -43,6 +43,14 @@
 #include "pcap.h"
 #include "compat.h"
 #include "response_time_index.h"
+#if defined(HAVE_LIBGEOIP) && defined(HAVE_GEOIP_H)
+#define HAVE_GEOIP 1
+#include <GeoIP.h>
+#endif
+#if defined(HAVE_LIBMAXMINDDB) && defined(HAVE_MAXMINDDB_H)
+#define HAVE_MAXMINDDB 1
+#include <maxminddb.h>
+#endif
 
 #include "input_mode.h"
 #include "dnstap.h"
@@ -52,6 +60,7 @@
 #include <limits.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 
 extern int input_mode;
 extern int promisc_flag;

--- a/src/country_index.c
+++ b/src/country_index.c
@@ -41,6 +41,15 @@
 #include "hashtbl.h"
 #include "syslog_debug.h"
 #include "geoip.h"
+#if defined(HAVE_LIBGEOIP) && defined(HAVE_GEOIP_H)
+#define HAVE_GEOIP 1
+#include <GeoIP.h>
+#endif
+#if defined(HAVE_LIBMAXMINDDB) && defined(HAVE_MAXMINDDB_H)
+#define HAVE_MAXMINDDB 1
+#include <maxminddb.h>
+#endif
+
 #ifdef HAVE_MAXMINDDB
 #include "compat.h"
 #endif
@@ -50,6 +59,7 @@
 #endif
 #include <string.h>
 #include <strings.h>
+#include <stdlib.h>
 
 extern int                debug_flag;
 extern char*              geoip_v4_dat;

--- a/src/dnstap.c
+++ b/src/dnstap.c
@@ -42,6 +42,7 @@
 #include "dns_message.h"
 #include "config_hooks.h"
 #include "xmalloc.h"
+#include "dns_protocol.h"
 
 char* dnstap_network_ip4  = 0;
 char* dnstap_network_ip6  = 0;
@@ -432,7 +433,6 @@ static uv_pipe_t unix_server;
 static uv_tcp_t  tcp_server;
 static uv_udp_t  udp_server;
 
-extern int dns_protocol_handler(const u_char* buf, int len, void* udata);
 extern uint64_t statistics_interval;
 
 static int _set_ipv(transport_message* tm, const struct dnstap* m)

--- a/src/dnstap.h
+++ b/src/dnstap.h
@@ -34,10 +34,10 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config_hooks.h"
-
 #ifndef __dsc_dnstap_h
 #define __dsc_dnstap_h
+
+#include "config_hooks.h"
 
 void dnstap_init(enum dnstap_via via, const char* sock_or_host, int port);
 int  dnstap_run(void);

--- a/src/geoip.h
+++ b/src/geoip.h
@@ -35,15 +35,6 @@
 #ifndef __dsc_geoip_h
 #define __dsc_geoip_h
 
-#if defined(HAVE_LIBGEOIP) && defined(HAVE_GEOIP_H)
-#define HAVE_GEOIP 1
-#include <GeoIP.h>
-#endif
-#if defined(HAVE_LIBMAXMINDDB) && defined(HAVE_MAXMINDDB_H)
-#define HAVE_MAXMINDDB 1
-#include <maxminddb.h>
-#endif
-
 enum geoip_backend {
     geoip_backend_none,
     geoip_backend_libgeoip,

--- a/src/parse_conf.c
+++ b/src/parse_conf.c
@@ -43,10 +43,19 @@
 #include "dns_message.h"
 #include "compat.h"
 #include "client_subnet_index.h"
+#if defined(HAVE_LIBGEOIP) && defined(HAVE_GEOIP_H)
+#define HAVE_GEOIP 1
+#include <GeoIP.h>
+#endif
+#if defined(HAVE_LIBMAXMINDDB) && defined(HAVE_MAXMINDDB_H)
+#define HAVE_MAXMINDDB 1
+#include <maxminddb.h>
+#endif
 
 #include <errno.h>
 #include <string.h>
 #include <stdlib.h>
+#include <stdio.h>
 
 #define PARSE_CONF_EINVAL -2
 #define PARSE_CONF_ERROR -1


### PR DESCRIPTION
- Remove GeoIP from SUSE packages, deprecated
- Fix compile warnings and include headers when GeoIP is missing
- `asn_indexer`: Fix bug, said unknown IPv4 when it was IPv6