### PR TITLE
DNSTAP socket

### DIFF
--- a/src/config_hooks.h
+++ b/src/config_hooks.h
@@ -46,7 +46,7 @@ enum dnstap_via {
 };
 
 int open_interface(const char* interface);
-int open_dnstap(enum dnstap_via via, const char* file_or_ip, const char* port);
+int open_dnstap(enum dnstap_via via, const char* file_or_ip, const char* port, const char* user, const char* group, const char* umask);
 int set_bpf_program(const char* s);
 int add_local_address(const char* s, const char* m);
 int set_run_dir(const char* dir);

--- a/src/dnstap.h
+++ b/src/dnstap.h
@@ -38,8 +38,9 @@
 #define __dsc_dnstap_h
 
 #include "config_hooks.h"
+#include <unistd.h>
 
-void dnstap_init(enum dnstap_via via, const char* sock_or_host, int port);
+void dnstap_init(enum dnstap_via via, const char* sock_or_host, int port, uid_t uid, gid_t gid, int mask);
 int  dnstap_run(void);
 void dnstap_stop(void);
 void dnstap_close(void);

--- a/src/dsc.conf.5.in
+++ b/src/dsc.conf.5.in
@@ -142,7 +142,7 @@ that is not directly related to the host.
 .TP
 \fBdnstap_file\fR FILE ;
 .TQ
-\fBdnstap_unixsock\fR FILE ;
+\fBdnstap_unixsock\fR FILE [ USER ][ :GROUP ] [ UMASK ] ;
 .TQ
 \fBdnstap_tcp\fR IP PORT ;
 .TQ
@@ -156,6 +156,25 @@ See
 https://dnstap.info
 .UE
 for more information about DNSTAP.
+
+For UNIX sockets there are additional optional options to control access
+to it.
+The user and group access are specified together as strings (USER:GROUP),
+separated with a colon if a group is specified.
+The file permissions are controlled by a file mode creation mask (UMASK,
+must being with 0) which is set temporarily during socket creation.
+It is not necessary to specify all options, you can specify only USER,
+only :GROUP or only UMASK.
+
+Example below shows how to give read and write access to somegroup,
+remove permissions for others and how the resulting socket file permissions
+would be:
+
+.EX
+  dnstap_unixsock /path/to/file.sock :somegroup 0007;
+
+  srwxrwx--- 1 root somegroup    0 Date dd HH:MM /path/to/file.sock
+.EE
 
 NOTE:
 .RS
@@ -865,6 +884,12 @@ pid_file "/run/dsc.pid";
 #drop_ip_fragments;
 interface eth0;
 #interface any;
+
+#dnstap_file /path/to/file.dnstap;
+#dnstap_unixsock /path/to/unix.sock;
+#dnstap_tcp 127.0.0.1 5353;
+#dnstap_udp 127.0.0.1 5353;
+#dnstap_network 127.0.0.1 ::1 53;
 
 dataset qtype dns All:null Qtype:qtype queries-only;
 dataset rcode dns All:null Rcode:rcode replies-only;

--- a/src/dsc.conf.sample.in
+++ b/src/dsc.conf.sample.in
@@ -100,6 +100,11 @@ pid_file "@DSC_PID_FILE@";
 #  as encapsulated DNS packets as seen or as made by the software.
 #  See https://dnstap.info for more information about DNSTAP.
 #
+#  dnstap_unixsock can have additional optional options to control access
+#  to the socket: [user][:group] [umask]
+#
+#    dnstap_unixsock /path/to/unix.sock user:group 0007;
+#
 #  NOTE:
 #  - Only one DNSTAP input can be specified at a time currently.
 #  - Configuration needs to match that of the DNS software.


### PR DESCRIPTION
- `dsc.conf`:
  - `dnstap_unixsock`: Add optional options to control ownership and permissions for the DNSTAP socket
- `dnstap`: Unlink socket file if an error occur after creating it in the initialization