### PR TITLE
country, asn

### DIFF
--- a/src/asn_index.c
+++ b/src/asn_index.c
@@ -82,6 +82,7 @@ static GeoIP* geoip6 = NULL;
 #ifdef HAVE_MAXMINDDB
 static MMDB_s mmdb;
 static char   _mmasn[32];
+static int    have_mmdb = 0;
 #endif
 static char ipstr[81];
 #ifdef HAVE_GEOIP
@@ -140,48 +141,49 @@ asn_get_from_message(dns_message* m)
             }
 #endif
             break;
-        case geoip_backend_libmaxminddb: {
+        case geoip_backend_libmaxminddb:
 #ifdef HAVE_MAXMINDDB
-            struct sockaddr_in   s;
-            int                  ret;
-            MMDB_lookup_result_s r;
+            if (have_mmdb) {
+                struct sockaddr_in   s;
+                int                  ret;
+                MMDB_lookup_result_s r;
 
-            s.sin_family = AF_INET;
-            s.sin_addr   = tm->src_ip_addr._.in4;
+                s.sin_family = AF_INET;
+                s.sin_addr   = tm->src_ip_addr._.in4;
 
-            r = MMDB_lookup_sockaddr(&mmdb, (struct sockaddr*)&s, &ret);
-            if (ret == MMDB_SUCCESS && r.found_entry) {
-                MMDB_entry_data_s entry_data;
+                r = MMDB_lookup_sockaddr(&mmdb, (struct sockaddr*)&s, &ret);
+                if (ret == MMDB_SUCCESS && r.found_entry) {
+                    MMDB_entry_data_s entry_data;
 
-                if (MMDB_get_value(&r.entry, &entry_data, "autonomous_system_number", 0) == MMDB_SUCCESS) {
-                    switch (entry_data.type) {
-                    case MMDB_DATA_TYPE_UINT16:
-                        snprintf(_mmasn, sizeof(_mmasn), "%" PRIu16, entry_data.uint16);
-                        asn = _mmasn;
+                    if (MMDB_get_value(&r.entry, &entry_data, "autonomous_system_number", 0) == MMDB_SUCCESS) {
+                        switch (entry_data.type) {
+                        case MMDB_DATA_TYPE_UINT16:
+                            snprintf(_mmasn, sizeof(_mmasn), "%" PRIu16, entry_data.uint16);
+                            asn = _mmasn;
+                            break;
+                        case MMDB_DATA_TYPE_UINT32:
+                            snprintf(_mmasn, sizeof(_mmasn), "%" PRIu32, entry_data.uint32);
+                            asn = _mmasn;
+                            break;
+                        case MMDB_DATA_TYPE_INT32:
+                            snprintf(_mmasn, sizeof(_mmasn), "%" PRId32, entry_data.int32);
+                            asn = _mmasn;
+                            break;
+                        case MMDB_DATA_TYPE_UINT64:
+                            snprintf(_mmasn, sizeof(_mmasn), "%" PRIu64, entry_data.uint64);
+                            asn = _mmasn;
+                            break;
+                        default:
+                            dfprintf(1, "asn_index: found entry in MMDB but unknown type %u", entry_data.type);
+                            asn = unknown_v4;
+                        }
                         break;
-                    case MMDB_DATA_TYPE_UINT32:
-                        snprintf(_mmasn, sizeof(_mmasn), "%" PRIu32, entry_data.uint32);
-                        asn = _mmasn;
-                        break;
-                    case MMDB_DATA_TYPE_INT32:
-                        snprintf(_mmasn, sizeof(_mmasn), "%" PRId32, entry_data.int32);
-                        asn = _mmasn;
-                        break;
-                    case MMDB_DATA_TYPE_UINT64:
-                        snprintf(_mmasn, sizeof(_mmasn), "%" PRIu64, entry_data.uint64);
-                        asn = _mmasn;
-                        break;
-                    default:
-                        dfprintf(1, "asn_index: found entry in MMDB but unknown type %u", entry_data.type);
-                        asn = unknown_v4;
                     }
                 }
-            } else {
-                asn = unknown_v4;
             }
+            asn = unknown_v4;
 #endif
             break;
-        }
         default:
             break;
         }
@@ -211,48 +213,49 @@ asn_get_from_message(dns_message* m)
             }
 #endif
             break;
-        case geoip_backend_libmaxminddb: {
+        case geoip_backend_libmaxminddb:
 #ifdef HAVE_MAXMINDDB
-            struct sockaddr_in6  s;
-            int                  ret;
-            MMDB_lookup_result_s r;
+            if (have_mmdb) {
+                struct sockaddr_in6  s;
+                int                  ret;
+                MMDB_lookup_result_s r;
 
-            s.sin6_family = AF_INET;
-            s.sin6_addr   = tm->src_ip_addr.in6;
+                s.sin6_family = AF_INET;
+                s.sin6_addr   = tm->src_ip_addr.in6;
 
-            r = MMDB_lookup_sockaddr(&mmdb, (struct sockaddr*)&s, &ret);
-            if (ret == MMDB_SUCCESS && r.found_entry) {
-                MMDB_entry_data_s entry_data;
+                r = MMDB_lookup_sockaddr(&mmdb, (struct sockaddr*)&s, &ret);
+                if (ret == MMDB_SUCCESS && r.found_entry) {
+                    MMDB_entry_data_s entry_data;
 
-                if (MMDB_get_value(&r.entry, &entry_data, "autonomous_system_number", 0) == MMDB_SUCCESS) {
-                    switch (entry_data.type) {
-                    case MMDB_DATA_TYPE_UINT16:
-                        snprintf(_mmasn, sizeof(_mmasn), "%" PRIu16, entry_data.uint16);
-                        asn = _mmasn;
+                    if (MMDB_get_value(&r.entry, &entry_data, "autonomous_system_number", 0) == MMDB_SUCCESS) {
+                        switch (entry_data.type) {
+                        case MMDB_DATA_TYPE_UINT16:
+                            snprintf(_mmasn, sizeof(_mmasn), "%" PRIu16, entry_data.uint16);
+                            asn = _mmasn;
+                            break;
+                        case MMDB_DATA_TYPE_UINT32:
+                            snprintf(_mmasn, sizeof(_mmasn), "%" PRIu32, entry_data.uint32);
+                            asn = _mmasn;
+                            break;
+                        case MMDB_DATA_TYPE_INT32:
+                            snprintf(_mmasn, sizeof(_mmasn), "%" PRId32, entry_data.int32);
+                            asn = _mmasn;
+                            break;
+                        case MMDB_DATA_TYPE_UINT64:
+                            snprintf(_mmasn, sizeof(_mmasn), "%" PRIu64, entry_data.uint64);
+                            asn = _mmasn;
+                            break;
+                        default:
+                            dfprintf(1, "asn_index: found entry in MMDB but unknown type %u", entry_data.type);
+                            asn = unknown_v6;
+                        }
                         break;
-                    case MMDB_DATA_TYPE_UINT32:
-                        snprintf(_mmasn, sizeof(_mmasn), "%" PRIu32, entry_data.uint32);
-                        asn = _mmasn;
-                        break;
-                    case MMDB_DATA_TYPE_INT32:
-                        snprintf(_mmasn, sizeof(_mmasn), "%" PRId32, entry_data.int32);
-                        asn = _mmasn;
-                        break;
-                    case MMDB_DATA_TYPE_UINT64:
-                        snprintf(_mmasn, sizeof(_mmasn), "%" PRIu64, entry_data.uint64);
-                        asn = _mmasn;
-                        break;
-                    default:
-                        dfprintf(1, "asn_index: found entry in MMDB but unknown type %u", entry_data.type);
-                        asn = unknown_v6;
                     }
                 }
-            } else {
-                asn = unknown_v6;
             }
+            asn = unknown_v6;
 #endif
             break;
-        }
         default:
             break;
         }
@@ -373,27 +376,26 @@ void asn_init(void)
         }
 #endif
         break;
-    case geoip_backend_libmaxminddb: {
+    case geoip_backend_libmaxminddb:
 #ifdef HAVE_MAXMINDDB
-        int  ret;
-        char errbuf[512];
+        if (maxminddb_asn) {
+            int  ret;
+            char errbuf[512];
 
-        if (!maxminddb_asn) {
-            dsyslog(LOG_ERR, "asn_index: Error no MaxMind ASN DB configured");
-            exit(1);
+            ret = MMDB_open(maxminddb_asn, 0, &mmdb);
+            if (ret == MMDB_IO_ERROR) {
+                dsyslogf(LOG_ERR, "asn_index: Error opening MaxMind ASN, IO error: %s", dsc_strerror(errno, errbuf, sizeof(errbuf)));
+                exit(1);
+            } else if (ret != MMDB_SUCCESS) {
+                dsyslogf(LOG_ERR, "asn_index: Error opening MaxMind ASN: %s", MMDB_strerror(ret));
+                exit(1);
+            }
+            dsyslog(LOG_INFO, "asn_index: Sucessfully initialized MaxMind ASN");
+        } else {
+            dsyslog(LOG_INFO, "asn_index: No database loaded for MaxMind ASN");
         }
-        ret = MMDB_open(maxminddb_asn, 0, &mmdb);
-        if (ret == MMDB_IO_ERROR) {
-            dsyslogf(LOG_ERR, "asn_index: Error opening MaxMind ASN DB, IO error: %s", dsc_strerror(errno, errbuf, sizeof(errbuf)));
-            exit(1);
-        } else if (ret != MMDB_SUCCESS) {
-            dsyslogf(LOG_ERR, "asn_index: Error opening MaxMind ASN DB: %s", MMDB_strerror(ret));
-            exit(1);
-        }
-        dsyslog(LOG_INFO, "asn_index: Sucessfully initialized MaxMind ASN DB");
 #endif
         break;
-    }
     default:
         break;
     }

--- a/src/config_hooks.c
+++ b/src/config_hooks.c
@@ -615,11 +615,11 @@ const char** KnownTLDS = KnownTLDS_static;
 
 int load_knowntlds(const char* file)
 {
-    FILE*   fp;
-    char *  buffer        = 0, *p;
-    size_t  bufsize       = 0;
-    char**  new_KnownTLDS = 0;
-    size_t  new_size      = 0;
+    FILE*  fp;
+    char * buffer        = 0, *p;
+    size_t bufsize       = 0;
+    char** new_KnownTLDS = 0;
+    size_t new_size      = 0;
 
     if (KnownTLDS != KnownTLDS_static) {
         dsyslog(LOG_ERR, "Known TLDs already loaded once");

--- a/src/country_index.c
+++ b/src/country_index.c
@@ -81,6 +81,7 @@ static GeoIP* geoip6 = NULL;
 #ifdef HAVE_MAXMINDDB
 static MMDB_s mmdb;
 static char   _mmcountry[32];
+static int    have_mmdb = 0;
 #endif
 static char  ipstr[81];
 static char* unknown    = "??";
@@ -119,32 +120,33 @@ country_get_from_message(dns_message* m)
             }
 #endif
             break;
-        case geoip_backend_libmaxminddb: {
+        case geoip_backend_libmaxminddb:
 #ifdef HAVE_MAXMINDDB
-            struct sockaddr_in   s;
-            int                  ret;
-            MMDB_lookup_result_s r;
+            if (have_mmdb) {
+                struct sockaddr_in   s;
+                int                  ret;
+                MMDB_lookup_result_s r;
 
-            s.sin_family = AF_INET;
-            s.sin_addr   = tm->src_ip_addr._.in4;
+                s.sin_family = AF_INET;
+                s.sin_addr   = tm->src_ip_addr._.in4;
 
-            r = MMDB_lookup_sockaddr(&mmdb, (struct sockaddr*)&s, &ret);
-            if (ret == MMDB_SUCCESS && r.found_entry) {
-                MMDB_entry_data_s entry_data;
+                r = MMDB_lookup_sockaddr(&mmdb, (struct sockaddr*)&s, &ret);
+                if (ret == MMDB_SUCCESS && r.found_entry) {
+                    MMDB_entry_data_s entry_data;
 
-                if (MMDB_get_value(&r.entry, &entry_data, "country", "iso_code", 0) == MMDB_SUCCESS
-                    && entry_data.type == MMDB_DATA_TYPE_UTF8_STRING) {
-                    size_t len = entry_data.data_size > (sizeof(_mmcountry) - 1) ? (sizeof(_mmcountry) - 1) : entry_data.data_size;
-                    memcpy(_mmcountry, entry_data.utf8_string, len);
-                    _mmcountry[len] = 0;
-                    cc              = _mmcountry;
-                    break;
+                    if (MMDB_get_value(&r.entry, &entry_data, "country", "iso_code", 0) == MMDB_SUCCESS
+                        && entry_data.type == MMDB_DATA_TYPE_UTF8_STRING) {
+                        size_t len = entry_data.data_size > (sizeof(_mmcountry) - 1) ? (sizeof(_mmcountry) - 1) : entry_data.data_size;
+                        memcpy(_mmcountry, entry_data.utf8_string, len);
+                        _mmcountry[len] = 0;
+                        cc              = _mmcountry;
+                        break;
+                    }
                 }
             }
             cc = unknown_v4;
 #endif
             break;
-        }
         default:
             break;
         }
@@ -162,32 +164,33 @@ country_get_from_message(dns_message* m)
             }
 #endif
             break;
-        case geoip_backend_libmaxminddb: {
+        case geoip_backend_libmaxminddb:
 #ifdef HAVE_MAXMINDDB
-            struct sockaddr_in6  s;
-            int                  ret;
-            MMDB_lookup_result_s r;
+            if (have_mmdb) {
+                struct sockaddr_in6  s;
+                int                  ret;
+                MMDB_lookup_result_s r;
 
-            s.sin6_family = AF_INET;
-            s.sin6_addr   = tm->src_ip_addr.in6;
+                s.sin6_family = AF_INET;
+                s.sin6_addr   = tm->src_ip_addr.in6;
 
-            r = MMDB_lookup_sockaddr(&mmdb, (struct sockaddr*)&s, &ret);
-            if (ret == MMDB_SUCCESS && r.found_entry) {
-                MMDB_entry_data_s entry_data;
+                r = MMDB_lookup_sockaddr(&mmdb, (struct sockaddr*)&s, &ret);
+                if (ret == MMDB_SUCCESS && r.found_entry) {
+                    MMDB_entry_data_s entry_data;
 
-                if (MMDB_get_value(&r.entry, &entry_data, "country", "iso_code", 0) == MMDB_SUCCESS
-                    && entry_data.type == MMDB_DATA_TYPE_UTF8_STRING) {
-                    size_t len = entry_data.data_size > (sizeof(_mmcountry) - 1) ? (sizeof(_mmcountry) - 1) : entry_data.data_size;
-                    memcpy(_mmcountry, entry_data.utf8_string, len);
-                    _mmcountry[len] = 0;
-                    cc              = _mmcountry;
-                    break;
+                    if (MMDB_get_value(&r.entry, &entry_data, "country", "iso_code", 0) == MMDB_SUCCESS
+                        && entry_data.type == MMDB_DATA_TYPE_UTF8_STRING) {
+                        size_t len = entry_data.data_size > (sizeof(_mmcountry) - 1) ? (sizeof(_mmcountry) - 1) : entry_data.data_size;
+                        memcpy(_mmcountry, entry_data.utf8_string, len);
+                        _mmcountry[len] = 0;
+                        cc              = _mmcountry;
+                        break;
+                    }
                 }
             }
             cc = unknown_v6;
 #endif
             break;
-        }
         default:
             break;
         }
@@ -296,27 +299,27 @@ void country_init(void)
         }
 #endif
         break;
-    case geoip_backend_libmaxminddb: {
+    case geoip_backend_libmaxminddb:
 #ifdef HAVE_MAXMINDDB
-        int  ret;
-        char errbuf[512];
+        if (maxminddb_country) {
+            int  ret;
+            char errbuf[512];
 
-        if (!maxminddb_country) {
-            dsyslog(LOG_ERR, "country_index: Error no MaxMind ASN DB configured");
-            exit(1);
+            ret = MMDB_open(maxminddb_country, 0, &mmdb);
+            if (ret == MMDB_IO_ERROR) {
+                dsyslogf(LOG_ERR, "country_index: Error opening MaxMind Country, IO error: %s", dsc_strerror(errno, errbuf, sizeof(errbuf)));
+                exit(1);
+            } else if (ret != MMDB_SUCCESS) {
+                dsyslogf(LOG_ERR, "country_index: Error opening MaxMind Country: %s", MMDB_strerror(ret));
+                exit(1);
+            }
+            dsyslog(LOG_INFO, "country_index: Sucessfully initialized MaxMind Country");
+            have_mmdb = 1;
+        } else {
+            dsyslog(LOG_INFO, "country_index: No database loaded for MaxMind Country");
         }
-        ret = MMDB_open(maxminddb_country, 0, &mmdb);
-        if (ret == MMDB_IO_ERROR) {
-            dsyslogf(LOG_ERR, "country_index: Error opening MaxMind ASN DB, IO error: %s", dsc_strerror(errno, errbuf, sizeof(errbuf)));
-            exit(1);
-        } else if (ret != MMDB_SUCCESS) {
-            dsyslogf(LOG_ERR, "country_index: Error opening MaxMind ASN DB: %s", MMDB_strerror(ret));
-            exit(1);
-        }
-        dsyslog(LOG_INFO, "country_index: Sucessfully initialized MaxMind ASN DB");
 #endif
         break;
-    }
     default:
         break;
     }


### PR DESCRIPTION
- `asn_indexer`: Allow running without a MaxMind database (same behavior as GeoIP)
- `country_indexer`:
  - Allow running without a MaxMind database (same behavior as GeoIP)
  - Fix typo in logging when loaded database