### PR TITLE
getline

### DIFF
--- a/src/config_hooks.c
+++ b/src/config_hooks.c
@@ -638,7 +638,7 @@ int load_knowntlds(const char* file)
     new_KnownTLDS[new_size] = ".";
     new_size++;
 
-    while (getline(&buffer, &bufsize, fp) > 0) {
+    while (getline(&buffer, &bufsize, fp) > 0 && buffer) {
         for (p = buffer; *p; p++) {
             if (*p == '\r' || *p == '\n') {
                 *p = 0;

--- a/src/parse_conf.c
+++ b/src/parse_conf.c
@@ -1162,7 +1162,7 @@ int parse_conf(const char* file)
     if (!(fp = fopen(file, "r"))) {
         return 1;
     }
-    while ((ret2 = getline(&buffer, &bufsize, fp)) > 0) {
+    while ((ret2 = getline(&buffer, &bufsize, fp)) > 0 && buffer) {
         memset(tokens, 0, sizeof(conf_token_t) * PARSE_MAX_ARGS);
         line++;
         /*


### PR DESCRIPTION
- Fix sonar issues by checking the buffer returned by `getline()`