### PR TITLE
GeoIP

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ General support and discussion:
 environment with autoconf, automake, libtool and pkgconfig.
 
 `dsc` has a non-optional dependency on the PCAP library and optional
-dependency on the GeoIP library (for the `asn` and `country` indexer).
+dependency on the MaxMindDB library (for the `asn` and `country` indexer).
 
 To install the dependencies under Debian/Ubuntu:
 ```

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: net
 Priority: optional
 Maintainer: Jerry Lundström <lundstrom.jerry@gmail.com>
 Build-Depends: debhelper (>= 10), build-essential, automake, autoconf,
- libpcap-dev, netbase, libgeoip-dev, pkg-config, libmaxminddb-dev,
+ libpcap-dev, netbase, pkg-config, libmaxminddb-dev,
  libdnswire-dev (>= 0.3.0), libuv1-dev, python3 (>= 3.5)
 Standards-Version: 3.9.4
 Homepage: https://www.dns-oarc.net/oarc/data/dsc

--- a/rpm/dsc.spec
+++ b/rpm/dsc.spec
@@ -11,12 +11,7 @@ URL:            https://www.dns-oarc.net/oarc/data/dsc
 Source0:        https://www.dns-oarc.net/files/dsc/%{name}-%{version}.tar.gz?/%{name}_%{version}.orig.tar.gz
 
 BuildRequires:  libpcap-devel
-%if 0%{?suse_version} || 0%{?sle_version}
 BuildRequires:  libmaxminddb-devel
-%else
-BuildRequires:  GeoIP-devel
-BuildRequires:  libmaxminddb-devel
-%endif
 BuildRequires:  autoconf
 BuildRequires:  automake
 BuildRequires:  libtool


### PR DESCRIPTION
- Phase out GeoIP (obsolete library)
  - Remove GeoIP from packages
  - Indicate MaxMindDB library should be used instead