### PR TITLE
Output file access

### DIFF
--- a/src/config_hooks.h
+++ b/src/config_hooks.h
@@ -81,5 +81,8 @@ int  set_response_time_max_sec_mode(const char* s);
 int  set_response_time_bucket_size(const char* s);
 int  load_knowntlds(const char* file);
 int  load_tld_list(const char* file);
+int  set_output_user(const char* user);
+int  set_output_group(const char* group);
+int  set_output_mod(const char* mod);
 
 #endif /* __dsc_config_hooks_h */

--- a/src/dsc.conf.5.in
+++ b/src/dsc.conf.5.in
@@ -242,6 +242,19 @@ any number of times.
 Default output format is XML, see section DATA FORMATS and FILE NAMING
 CONVENTIONS.
 .TP
+\fBoutput_user\fR USER ;
+Specify which user should own the output file, default to the user running
+.IR dsc .
+.TP
+\fBoutput_group\fR GROUP ;
+Specify which group should own the output file, default to the group of the
+user running
+.IR dsc .
+.TP
+\fBoutput_mod\fR FILE_MODE_BITS ;
+Specify the file mode bits (in octal) for the output file permissions,
+default to 0664.
+.TP
 \fBdump_reports_on_exit\fR ;
 Dump any remaining report before exiting.
 
@@ -965,6 +978,9 @@ dataset direction_vs_ipproto ip Direction:ip_direction IPProto:ip_proto any;
 #no_wait_interval;
 output_format XML;
 #output_format JSON;
+#output_user root;
+#output_group root;
+#output_mod 0664;
 
 #geoip_v4_dat "/usr/share/GeoIP/GeoIP.dat" STANDARD MEMORY_CACHE MMAP_CACHE;
 #geoip_v6_dat "/usr/share/GeoIP/GeoIPv6.dat";

--- a/src/dsc.conf.sample.in
+++ b/src/dsc.conf.sample.in
@@ -224,6 +224,15 @@ dataset direction_vs_ipproto ip Direction:ip_direction IPProto:ip_proto any;
 #output_format XML;
 #output_format JSON;
 
+# output file access
+#
+#   Following options controls the user, group and file mode bits for the
+#   output file.
+#
+#output_user root;
+#output_group root;
+#output_mod 0664;
+
 # dump_reports_on_exit
 #
 #   Dump any remaining report before exiting.

--- a/src/parse_conf.c
+++ b/src/parse_conf.c
@@ -952,6 +952,51 @@ int parse_conf_tld_list(const conf_token_t* tokens)
     return ret == 1 ? 0 : 1;
 }
 
+int parse_conf_output_user(const conf_token_t* tokens)
+{
+    char* user = strndup(tokens[1].token, tokens[1].length);
+    int   ret;
+
+    if (!user) {
+        errno = ENOMEM;
+        return -1;
+    }
+
+    ret = set_output_user(user);
+    free(user);
+    return ret == 1 ? 0 : 1;
+}
+
+int parse_conf_output_group(const conf_token_t* tokens)
+{
+    char* group = strndup(tokens[1].token, tokens[1].length);
+    int   ret;
+
+    if (!group) {
+        errno = ENOMEM;
+        return -1;
+    }
+
+    ret = set_output_group(group);
+    free(group);
+    return ret == 1 ? 0 : 1;
+}
+
+int parse_conf_output_mod(const conf_token_t* tokens)
+{
+    char* mod = strndup(tokens[1].token, tokens[1].length);
+    int   ret;
+
+    if (!mod) {
+        errno = ENOMEM;
+        return -1;
+    }
+
+    ret = set_output_mod(mod);
+    free(mod);
+    return ret == 1 ? 0 : 1;
+}
+
 static conf_token_syntax_t _syntax[] = {
     { "interface",
         parse_conf_interface,
@@ -1076,6 +1121,15 @@ static conf_token_syntax_t _syntax[] = {
     { "tld_list",
         parse_conf_tld_list,
         { TOKEN_STRING, TOKEN_END } },
+    { "output_user",
+        parse_conf_output_user,
+        { TOKEN_STRING, TOKEN_END } },
+    { "output_group",
+        parse_conf_output_group,
+        { TOKEN_STRING, TOKEN_END } },
+    { "output_mod",
+        parse_conf_output_mod,
+        { TOKEN_NUMBER, TOKEN_END } },
 
     { 0, 0, { TOKEN_END } }
 };

--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -14,13 +14,14 @@ CLEANFILES = test*.log test*.trs \
   test12.out \
   1458044657.tld_list.dist \
   tld_list.dat \
-  dotdoh.dnstap.dist 1643283234.dscdata.xml
+  dotdoh.dnstap.dist 1643283234.dscdata.xml \
+  test13.conf
 
 EXTRA_DIST =
 
 TESTS = test1.sh test2.sh test3.sh test4.sh test6.sh test7.sh test8.sh \
   test9.sh test10.sh test11.sh test12.sh test_dnstap_unixsock.sh \
-  test_dnstap_tcp.sh test_pslconv.sh test_encrypted.sh
+  test_dnstap_tcp.sh test_pslconv.sh test_encrypted.sh test13.sh
 
 if USE_DNSTAP
 TESTS += test5.sh
@@ -75,6 +76,8 @@ test_encrypted.sh: dotdoh.dnstap.dist
 
 dotdoh.dnstap.dist: dotdoh.dnstap
 	ln -s "$(srcdir)/dotdoh.dnstap" dotdoh.dnstap.dist
+
+test13.sh: 1458044657.pcap.dist 1458044657.tld_list.dist
 
 EXTRA_DIST += $(TESTS) \
   1458044657.conf 1458044657.pcap 1458044657.json_gold 1458044657.xml_gold \

--- a/src/test/test13.sh
+++ b/src/test/test13.sh
@@ -1,0 +1,23 @@
+#!/bin/sh -xe
+
+rm -f 1458044657.dscdata.json 1458044657.dscdata.xml
+
+rm -f test13.conf
+cp "$srcdir/1458044657.conf" test13.conf
+echo "output_user `id -nu`;" >>test13.conf
+echo "output_group `id -ng`;" >>test13.conf
+echo "output_mod 0644;" >>test13.conf
+
+../dsc test13.conf
+
+test -f 1458044657.dscdata.json || sleep 1
+test -f 1458044657.dscdata.json || sleep 2
+test -f 1458044657.dscdata.json || sleep 3
+test -f 1458044657.dscdata.json
+test "`stat -c "%a" 1458044657.dscdata.json`" = "644" || test "`perl -e 'printf("%o\n", (stat("1458044657.dscdata.json"))[2])'`" = "100644"
+
+test -f 1458044657.dscdata.xml || sleep 1
+test -f 1458044657.dscdata.xml || sleep 2
+test -f 1458044657.dscdata.xml || sleep 3
+test -f 1458044657.dscdata.xml
+test "`stat -c "%a" 1458044657.dscdata.xml`" = "644" || test "`perl -e 'printf("%o\n", (stat("1458044657.dscdata.xml"))[2])'`" = "100644"


### PR DESCRIPTION
- Fix #279: Add new conf options to control output file access:
  - `output_user`: set output file user ownership
  - `output_group`: set output file group ownership
  - `output_mod`: set output file mode bits