### PR TITLE
strtohex, nsid text

### DIFF
--- a/src/dns_message.c
+++ b/src/dns_message.c
@@ -128,6 +128,7 @@ static indexer indexers[] = {
     { "edns_nsid", indexer_want_edns_options, edns_nsid_indexer, edns_nsid_iterator },
     { "edns_nsid_len", indexer_want_edns_options, edns_nsid_len_indexer, edns_nsid_len_iterator, edns_nsid_len_reset },
     { "edns_nsid_data", indexer_want_edns_options, edns_nsid_data_indexer, edns_nsid_data_iterator, edns_nsid_data_reset },
+    { "edns_nsid_text", indexer_want_edns_options, edns_nsid_text_indexer, edns_nsid_text_iterator, edns_nsid_text_reset },
     { "do_bit", 0, do_bit_indexer, do_bit_iterator },
     { "rd_bit", 0, rd_bit_indexer, rd_bit_iterator },
     { "tc_bit", 0, tc_bit_indexer, tc_bit_iterator },

--- a/src/dsc.conf.5.in
+++ b/src/dsc.conf.5.in
@@ -562,6 +562,10 @@ The length of the EDNS(0) DNS Name Server Identifier (NSID).
 \fBedns_nsid_data\fR
 The EDNS(0) DNS Name Server Identifier (NSID) bytes as a hexadecimal string.
 .TP
+\fBedns_nsid_text\fR
+The EDNS(0) DNS Name Server Identifier (NSID) as a string of printable characters.
+Unprintable characters are replaced with ".".
+.TP
 \fBidn_qname\fR
 This indexer has only two values: 0 or 1.
 It returns 1 when the first QNAME in the DNS message question section

--- a/src/edns_nsid_index.h
+++ b/src/edns_nsid_index.h
@@ -50,4 +50,8 @@ int  edns_nsid_data_indexer(const dns_message*);
 int  edns_nsid_data_iterator(const char** label);
 void edns_nsid_data_reset(void);
 
+int  edns_nsid_text_indexer(const dns_message*);
+int  edns_nsid_text_iterator(const char** label);
+void edns_nsid_text_reset(void);
+
 #endif /* __dsc_edns_nsid_index_h */

--- a/src/hashtbl.c
+++ b/src/hashtbl.c
@@ -162,7 +162,7 @@ void strtohex(char* dst, const char* src, size_t len)
     const char xx[] = "0123456789ABCDEF";
     size_t     i;
     for (i = 0; i < len; i++) {
-        dst[i * 2]     = xx[(unsigned char)src[i] & 0xf];
-        dst[i * 2 + 1] = xx[(unsigned char)src[i] >> 4];
+        dst[i * 2]     = xx[(unsigned char)src[i] >> 4];
+        dst[i * 2 + 1] = xx[(unsigned char)src[i] & 0xf];
     }
 }

--- a/src/test/test_291.conf
+++ b/src/test/test_291.conf
@@ -7,6 +7,7 @@ dataset edns_bufsiz dns All:null EDNSBufSiz:edns_bufsiz queries-only;
 dataset edns_nsid dns All:null edns_nsid:edns_nsid;
 dataset edns_nsid_len dns All:null edns_nsid_len:edns_nsid_len edns0-only;
 dataset edns_nsid_data dns All:null edns_nsid_data:edns_nsid_data edns0-only;
+dataset edns_nsid_text dns All:null edns_nsid_text:edns_nsid_text edns0-only;
 dataset edns_cookie dns All:null edns_cookie:edns_cookie;
 dataset edns_cookie_len dns All:null edns_cookie_len:edns_cookie_len edns0-only;
 dataset edns_cookie_client dns All:null edns_cookie_client:edns_cookie_client edns0-only;

--- a/src/test/test_291.xml_gold
+++ b/src/test/test_291.xml_gold
@@ -61,7 +61,7 @@
   <dimension number="2" type="edns_ecs_address"/>
   <data>
     <All val="ALL">
-      <edns_ecs_address val="CA1100" count="2"/>
+      <edns_ecs_address val="AC1100" count="2"/>
     </All>
   </data>
 </array>
@@ -110,7 +110,7 @@
   <dimension number="2" type="edns_cookie_server"/>
   <data>
     <All val="ALL">
-      <edns_cookie_server val="10000000465AA160277069BC52DDB85E" count="1"/>
+      <edns_cookie_server val="0100000064A51A06720796CB25DD8BE5" count="1"/>
     </All>
   </data>
 </array>
@@ -119,9 +119,9 @@
   <dimension number="2" type="edns_cookie_client"/>
   <data>
     <All val="ALL">
-      <edns_cookie_client val="2A801E4FA7BFCD4B" count="2"/>
-      <edns_cookie_client val="A8EC1C7B804E6CE4" count="1"/>
-      <edns_cookie_client val="662F3B908BF45C0D" count="1"/>
+      <edns_cookie_client val="A208E1F47AFBDCB4" count="2"/>
+      <edns_cookie_client val="8ACEC1B708E4C64E" count="1"/>
+      <edns_cookie_client val="66F2B309B84FC5D0" count="1"/>
     </All>
   </data>
 </array>
@@ -146,12 +146,21 @@
     </All>
   </data>
 </array>
+<array name="edns_nsid_text" dimensions="2" start_time="1688541698" stop_time="1688541706">
+  <dimension number="1" type="All"/>
+  <dimension number="2" type="edns_nsid_text"/>
+  <data>
+    <All val="ALL">
+      <edns_nsid_text val="001.fra.h.root-servers.org" count="1"/>
+    </All>
+  </data>
+</array>
 <array name="edns_nsid_data" dimensions="2" start_time="1688541698" stop_time="1688541706">
   <dimension number="1" type="All"/>
   <dimension number="2" type="edns_nsid_data"/>
   <data>
     <All val="ALL">
-      <edns_nsid_data val="030313E2662716E286E227F6F647D237562767562737E2F62776" count="1"/>
+      <edns_nsid_data val="3030312E6672612E682E726F6F742D736572766572732E6F7267" count="1"/>
     </All>
   </data>
 </array>


### PR DESCRIPTION
- Fix `strtohex()`, hex representation was reversed
- `ends_nsid`: Add `edns_nsid_text` indexer