### PR TITLE
Stack

### DIFF
--- a/src/response_time_index.c
+++ b/src/response_time_index.c
@@ -375,7 +375,7 @@ int response_time_indexer(const dns_message* m)
 
 int response_time_iterator(const char** label)
 {
-    char label_buf[128];
+    static char label_buf[128];
 
     if (!label) {
         next_iter = 0;


### PR DESCRIPTION
- `response_time_index`: Fix https://github.com/DNS-OARC/dsc/security/code-scanning/22 label buffer should be static